### PR TITLE
build(src): correct static library generation

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ export XVR_OUTDIR = out
 
 all: $(XVR_OUTDIR) inter
 
-inter: $(XVR_OUTDIR) library
+inter: $(XVR_OUTDIR) library static inter
 	$(MAKE) -C inter
 
 inter-static: $(XVR_OUTDIR) static
@@ -16,16 +16,16 @@ inter-static-release: clean $(XVR_OUTDIR) static-release
 	$(MAKE) -C inter release
 
 library: $(XVR_OUTDIR)
-	$(MAKE) -j8 -C src library
+	$(MAKE) -j$(nproc) -C src library
 
 static: $(XVR_OUTDIR)
-	$(MAKE) -j8 -C src static
+	$(MAKE) -j$(nproc) -C src static
 
 library-release: $(XVR_OUTDIR)
-	$(MAKE) -j8 -C src library-release
+	$(MAKE) -j$(nproc) -C src library-release
 
 static-release: $(XVR_OUTDIR)
-	$(MAKE) -j8 -C src static-release
+	$(MAKE) -j$(nproc) -C src static-release
 
 test: clean $(XVR_OUTDIR)
 	$(MAKE) -C test

--- a/src/makefile
+++ b/src/makefile
@@ -29,9 +29,10 @@ else
 endif
 
 library: $(OBJ)
-	$(CC) -DXVR_EXPORT $(CFLAGS) -shared -o $(OUT) $(LIBLINE)
+	$(CC) -DXVR_EXPORT $(CFLAGS) -shared -fPIC -o $(OUT) $(LIBLINE)
 
 static: $(OBJ)
+	$(RM) ../$(XVR_OUTDIR)/lib$(OUTNAME).a
 	ar crs ../$(XVR_OUTDIR)/lib$(OUTNAME).a $(OBJ)
 
 library-release: $(OBJ) library


### PR DESCRIPTION
Previously libxvr.a was created via --out-implib which produced a shared ELF file instead of a proper AR archive.

Static library is now produced via:
    ar crs ../out/libxvr.a $(OBJ)

Additional changes:
    - add -fPIC for shared builds
    - use $(nproc) instead of -j8