### PR TITLE
feat: implement std::max()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@
 *.log
 
 # Kernel Module Compile Results
-*.mod*
 *.cmd
 .tmp_versions/
 modules.order

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -49,7 +49,7 @@ var b = std::max(5, 5);                // b = 5 (returns first if equal)
 var c = std::max(-5, 10);              // c = 10
 var d = std::max(1.5, 2.5);            // d = 2.5 (works with floats)
 var e = std::max(3, 1, 2);             // e = 3 (multiple arguments)
-var f = std::max(10, 20, 30, 5, 15);   // f = 30 (many arguments)
+var f = std::max(10, 20, 30, 5);       // f = 30 (up to 4 args O(1), more O(n))
 std::print("max: {}\n", std::max(2221, 2313));  // prints: 2313
 ```
 
@@ -59,10 +59,12 @@ Supported types:
 - `double` - Double precision floating point
 
 Requirements:
-- At least one argument required
+- 1-8 arguments supported
 - All arguments must be the same type (int or float)
 
-Complexity: O(n) time where n is the number of arguments, O(1) auxiliary space
+Complexity:
+- 1-4 arguments: O(1) - constant time with unrolled comparisons
+- 5+ arguments: O(n) - linear time with loop
 
 ### String Concatenation
 

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -41,13 +41,15 @@ Supported types in format placeholders:
 
 ### std::max
 
-Returns the greater of two values:
+Returns the greater of two or more values:
 
 ```xvr
-var a = std::max(10, 20);    // a = 20
-var b = std::max(5, 5);      // b = 5 (returns first if equal)
-var c = std::max(-5, 10);    // c = 10
-var d = std::max(1.5, 2.5);  // d = 2.5 (works with floats)
+var a = std::max(10, 20);              // a = 20
+var b = std::max(5, 5);                // b = 5 (returns first if equal)
+var c = std::max(-5, 10);              // c = 10
+var d = std::max(1.5, 2.5);            // d = 2.5 (works with floats)
+var e = std::max(3, 1, 2);             // e = 3 (multiple arguments)
+var f = std::max(10, 20, 30, 5, 15);   // f = 30 (many arguments)
 std::print("max: {}\n", std::max(2221, 2313));  // prints: 2313
 ```
 
@@ -56,7 +58,11 @@ Supported types:
 - `float` - Single precision floating point
 - `double` - Double precision floating point
 
-Complexity: O(1) time, O(1) auxiliary space
+Requirements:
+- At least one argument required
+- All arguments must be the same type (int or float)
+
+Complexity: O(n) time where n is the number of arguments, O(1) auxiliary space
 
 ### String Concatenation
 

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -12,19 +12,32 @@ Include the standard library module:
 include std;
 ```
 
-This loads the stdlib module for use in your program.
+This loads the stdlib module for use in your program. Built-in functions like `std::print` and `std::max` are automatically available.
+
+## Built-in Functions
+
+These functions are built into the compiler and available without any additional setup:
 
 ### std::print
 
-Print output to the console:
+Print output to the console with format string support:
 
 ```xvr
 std::print("Hello, World!");
-std::print("Value: {}", 42);
-std::print("{} + {} = {}", 1, 2, 3);
+std::print("Value: {}\n", 42);
+std::print("int: {} float: {}\n", 42, 3.14);
+std::print("{} + {} = {}\n", 1, 2, 3);
 ```
 
-The `std::print` function uses `{}` placeholders for formatting.
+The `std::print` function uses `{}` placeholders for formatting:
+- `{}` - Auto-detects type (int, float, string)
+- Use `\n` in the format string for newlines
+
+Supported types in format placeholders:
+- `int` - Prints as decimal integer
+- `float` - Prints as floating point number
+- `string` - Prints the string content
+- `double` - Prints as double precision float
 
 ### std::max
 
@@ -35,12 +48,15 @@ var a = std::max(10, 20);    // a = 20
 var b = std::max(5, 5);      // b = 5 (returns first if equal)
 var c = std::max(-5, 10);    // c = 10
 var d = std::max(1.5, 2.5);  // d = 2.5 (works with floats)
+std::print("max: {}\n", std::max(2221, 2313));  // prints: 2313
 ```
 
 Supported types:
-- `int` - Integer values
+- `int` - Integer values (uses signed comparison)
 - `float` - Single precision floating point
 - `double` - Double precision floating point
+
+Complexity: O(1) time, O(1) auxiliary space
 
 ### String Concatenation
 

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -26,6 +26,22 @@ std::print("{} + {} = {}", 1, 2, 3);
 
 The `std::print` function uses `{}` placeholders for formatting.
 
+### std::max
+
+Returns the greater of two values:
+
+```xvr
+var a = std::max(10, 20);    // a = 20
+var b = std::max(5, 5);      // b = 5 (returns first if equal)
+var c = std::max(-5, 10);    // c = 10
+var d = std::max(1.5, 2.5);  // d = 2.5 (works with floats)
+```
+
+Supported types:
+- `int` - Integer values
+- `float` - Single precision floating point
+- `double` - Double precision floating point
+
 ### String Concatenation
 
 XVR supports both compile-time and runtime string concatenation:

--- a/lib/std/io.mod
+++ b/lib/std/io.mod
@@ -1,0 +1,14 @@
+# XVR IO Module
+# Provides input/output functions
+
+module io
+
+# Print functions
+# std::print("Hello") - prints without newline
+# std::println("Hello") - prints with newline
+
+native print(string)
+native println(string)
+native print_int(int)
+native print_float(float)
+native print_bool(bool)

--- a/lib/std/std.mod
+++ b/lib/std/std.mod
@@ -1,0 +1,18 @@
+# XVR Standard Library Module Definition
+# This file defines the std module
+
+module std
+
+# Re-export from io module
+export print
+export println
+
+# Re-export from string module  
+export string
+export string_length
+export string_concat
+
+# Re-export from memory module
+export memory
+export alloc
+export free

--- a/lib/std/std.mod
+++ b/lib/std/std.mod
@@ -7,6 +7,9 @@ module std
 export print
 export println
 
+# Re-export from math module
+export max
+
 # Re-export from string module  
 export string
 export string_length

--- a/src/backend/xvr_llvm_expression_emitter.c
+++ b/src/backend/xvr_llvm_expression_emitter.c
@@ -519,6 +519,12 @@ LLVMValueRef Xvr_LLVMExpressionEmitterEmitBinary(
                     "print() is not supported, use std::print() instead");
                 return NULL;
             }
+            if (fn_name && strcmp(fn_name, "max") == 0) {
+                Xvr_LLVMContextSetError(
+                    emitter->context,
+                    "max() is not supported, use std::max() instead");
+                return NULL;
+            }
 
             LLVMModuleRef module =
                 Xvr_LLVMModuleManagerGetModule(emitter->module);

--- a/src/backend/xvr_llvm_expression_emitter.c
+++ b/src/backend/xvr_llvm_expression_emitter.c
@@ -1030,21 +1030,19 @@ static LLVMValueRef emit_max(Xvr_LLVMExpressionEmitter* emitter,
     LLVMBuilderRef llvm_builder = Xvr_LLVMIRBuilderGetLLVMBuilder(builder);
 
     int arg_count = 0;
-    LLVMValueRef* args_list = NULL;
+    LLVMValueRef args_list[8] = {NULL};
 
     if (args->type == XVR_AST_NODE_COMPOUND) {
         arg_count = args->compound.count;
-        if (arg_count < 1) {
+        if (arg_count < 1 || arg_count > 8) {
             Xvr_LLVMContextSetError(emitter->context,
-                                    "max: requires at least one argument");
+                                    "max: requires 1-8 arguments");
             return NULL;
         }
-        args_list = (LLVMValueRef*)malloc(sizeof(LLVMValueRef) * arg_count);
         for (int i = 0; i < arg_count; i++) {
             args_list[i] = Xvr_LLVMExpressionEmitterEmit(
                 emitter, &args->compound.nodes[i]);
             if (!args_list[i]) {
-                free(args_list);
                 Xvr_LLVMContextSetError(emitter->context,
                                         "max: invalid argument");
                 return NULL;
@@ -1052,17 +1050,15 @@ static LLVMValueRef emit_max(Xvr_LLVMExpressionEmitter* emitter,
         }
     } else if (args->type == XVR_AST_NODE_FN_COLLECTION) {
         arg_count = args->fnCollection.count;
-        if (arg_count < 1) {
+        if (arg_count < 1 || arg_count > 8) {
             Xvr_LLVMContextSetError(emitter->context,
-                                    "max: requires at least one argument");
+                                    "max: requires 1-8 arguments");
             return NULL;
         }
-        args_list = (LLVMValueRef*)malloc(sizeof(LLVMValueRef) * arg_count);
         for (int i = 0; i < arg_count; i++) {
             args_list[i] = Xvr_LLVMExpressionEmitterEmit(
                 emitter, &args->fnCollection.nodes[i]);
             if (!args_list[i]) {
-                free(args_list);
                 Xvr_LLVMContextSetError(emitter->context,
                                         "max: invalid argument");
                 return NULL;
@@ -1073,41 +1069,114 @@ static LLVMValueRef emit_max(Xvr_LLVMExpressionEmitter* emitter,
         return NULL;
     }
 
-    LLVMValueRef max_val = args_list[0];
-    LLVMTypeRef max_type = LLVMTypeOf(max_val);
-    LLVMTypeKind max_kind = LLVMGetTypeKind(max_type);
+    LLVMTypeRef type0 = LLVMTypeOf(args_list[0]);
+    LLVMTypeKind kind0 = LLVMGetTypeKind(type0);
 
-    for (int i = 1; i < arg_count; i++) {
-        LLVMValueRef arg = args_list[i];
-        LLVMTypeRef arg_type = LLVMTypeOf(arg);
-        LLVMTypeKind arg_kind = LLVMGetTypeKind(arg_type);
-
-        LLVMValueRef cond = NULL;
-
-        if (max_kind == LLVMIntegerTypeKind &&
-            arg_kind == LLVMIntegerTypeKind) {
-            cond = LLVMBuildICmp(llvm_builder, LLVMIntSGT, max_val, arg,
-                                 "max_cmp");
-        } else if ((max_kind == LLVMFloatTypeKind &&
-                    arg_kind == LLVMFloatTypeKind) ||
-                   (max_kind == LLVMDoubleTypeKind &&
-                    arg_kind == LLVMDoubleTypeKind)) {
-            cond = LLVMBuildFCmp(llvm_builder, LLVMRealOGT, max_val, arg,
-                                 "max_cmp");
-        } else {
-            free(args_list);
-            Xvr_LLVMContextSetError(emitter->context,
-                                    "max: all arguments must be the same "
-                                    "comparable type (int or float)");
-            return NULL;
+    if (kind0 == LLVMIntegerTypeKind) {
+        switch (arg_count) {
+        case 1:
+            return args_list[0];
+        case 2: {
+            LLVMValueRef cond =
+                LLVMBuildICmp(llvm_builder, LLVMIntSGT, args_list[0],
+                              args_list[1], "max_cmp");
+            return LLVMBuildSelect(llvm_builder, cond, args_list[0],
+                                   args_list[1], "max_result");
         }
-
-        max_val =
-            LLVMBuildSelect(llvm_builder, cond, max_val, arg, "max_result");
+        case 3: {
+            LLVMValueRef tmp = args_list[0];
+            LLVMValueRef c1 = LLVMBuildICmp(llvm_builder, LLVMIntSGT, tmp,
+                                            args_list[1], "max_cmp1");
+            tmp = LLVMBuildSelect(llvm_builder, c1, tmp, args_list[1],
+                                  "max_tmp1");
+            LLVMValueRef c2 = LLVMBuildICmp(llvm_builder, LLVMIntSGT, tmp,
+                                            args_list[2], "max_cmp2");
+            return LLVMBuildSelect(llvm_builder, c2, tmp, args_list[2],
+                                   "max_result");
+        }
+        case 4: {
+            LLVMValueRef tmp = args_list[0];
+            LLVMValueRef c1 = LLVMBuildICmp(llvm_builder, LLVMIntSGT, tmp,
+                                            args_list[1], "max_cmp1");
+            tmp = LLVMBuildSelect(llvm_builder, c1, tmp, args_list[1],
+                                  "max_tmp1");
+            LLVMValueRef c2 = LLVMBuildICmp(llvm_builder, LLVMIntSGT, tmp,
+                                            args_list[2], "max_cmp2");
+            tmp = LLVMBuildSelect(llvm_builder, c2, tmp, args_list[2],
+                                  "max_tmp2");
+            LLVMValueRef c3 = LLVMBuildICmp(llvm_builder, LLVMIntSGT, tmp,
+                                            args_list[3], "max_cmp3");
+            return LLVMBuildSelect(llvm_builder, c3, tmp, args_list[3],
+                                   "max_result");
+        }
+        default: {
+            LLVMValueRef max_val = args_list[0];
+            for (int i = 1; i < arg_count; i++) {
+                LLVMValueRef cond = LLVMBuildICmp(
+                    llvm_builder, LLVMIntSGT, max_val, args_list[i], "max_cmp");
+                max_val = LLVMBuildSelect(llvm_builder, cond, max_val,
+                                          args_list[i], "max_result");
+            }
+            return max_val;
+        }
+        }
     }
 
-    free(args_list);
-    return max_val;
+    if (kind0 == LLVMFloatTypeKind || kind0 == LLVMDoubleTypeKind) {
+        switch (arg_count) {
+        case 1:
+            return args_list[0];
+        case 2: {
+            LLVMValueRef cond =
+                LLVMBuildFCmp(llvm_builder, LLVMRealOGT, args_list[0],
+                              args_list[1], "max_cmp");
+            return LLVMBuildSelect(llvm_builder, cond, args_list[0],
+                                   args_list[1], "max_result");
+        }
+        case 3: {
+            LLVMValueRef tmp = args_list[0];
+            LLVMValueRef c1 = LLVMBuildFCmp(llvm_builder, LLVMRealOGT, tmp,
+                                            args_list[1], "max_cmp1");
+            tmp = LLVMBuildSelect(llvm_builder, c1, tmp, args_list[1],
+                                  "max_tmp1");
+            LLVMValueRef c2 = LLVMBuildFCmp(llvm_builder, LLVMRealOGT, tmp,
+                                            args_list[2], "max_cmp2");
+            return LLVMBuildSelect(llvm_builder, c2, tmp, args_list[2],
+                                   "max_result");
+        }
+        case 4: {
+            LLVMValueRef tmp = args_list[0];
+            LLVMValueRef c1 = LLVMBuildFCmp(llvm_builder, LLVMRealOGT, tmp,
+                                            args_list[1], "max_cmp1");
+            tmp = LLVMBuildSelect(llvm_builder, c1, tmp, args_list[1],
+                                  "max_tmp1");
+            LLVMValueRef c2 = LLVMBuildFCmp(llvm_builder, LLVMRealOGT, tmp,
+                                            args_list[2], "max_cmp2");
+            tmp = LLVMBuildSelect(llvm_builder, c2, tmp, args_list[2],
+                                  "max_tmp2");
+            LLVMValueRef c3 = LLVMBuildFCmp(llvm_builder, LLVMRealOGT, tmp,
+                                            args_list[3], "max_cmp3");
+            return LLVMBuildSelect(llvm_builder, c3, tmp, args_list[3],
+                                   "max_result");
+        }
+        default: {
+            LLVMValueRef max_val = args_list[0];
+            for (int i = 1; i < arg_count; i++) {
+                LLVMValueRef cond =
+                    LLVMBuildFCmp(llvm_builder, LLVMRealOGT, max_val,
+                                  args_list[i], "max_cmp");
+                max_val = LLVMBuildSelect(llvm_builder, cond, max_val,
+                                          args_list[i], "max_result");
+            }
+            return max_val;
+        }
+        }
+    }
+
+    Xvr_LLVMContextSetError(
+        emitter->context,
+        "max: unsupported type - only int and float are supported");
+    return NULL;
 }
 
 /**

--- a/src/backend/xvr_llvm_expression_emitter.c
+++ b/src/backend/xvr_llvm_expression_emitter.c
@@ -822,9 +822,6 @@ static LLVMValueRef emit_printf(Xvr_LLVMExpressionEmitter* emitter,
     LLVMModuleRef module = Xvr_LLVMModuleManagerGetModule(emitter->module);
     LLVMBuilderRef llvm_builder = Xvr_LLVMIRBuilderGetLLVMBuilder(builder);
 
-    LLVMValueRef format_global =
-        LLVMBuildGlobalStringPtr(llvm_builder, "%s", "fmt_str");
-
     LLVMValueRef printf_fn = LLVMGetNamedFunction(module, "printf");
     if (!printf_fn) {
         LLVMTypeRef printf_type =
@@ -832,38 +829,39 @@ static LLVMValueRef emit_printf(Xvr_LLVMExpressionEmitter* emitter,
         printf_fn = LLVMAddFunction(module, "printf", printf_type);
     }
 
-    if (args->type == XVR_AST_NODE_COMPOUND) {
-        int arg_count = args->compound.count;
-        if (arg_count > 0) {
-            LLVMValueRef* call_args =
-                (LLVMValueRef*)malloc(sizeof(LLVMValueRef) * arg_count);
-            for (int i = 0; i < arg_count; i++) {
-                Xvr_ASTNode* arg = &args->compound.nodes[i];
-                LLVMValueRef arg_val =
-                    Xvr_LLVMExpressionEmitterEmit(emitter, arg);
-                if (arg_val) {
-                    call_args[i] = arg_val;
-                } else {
-                    call_args[i] = LLVMConstInt(
-                        LLVMInt32TypeInContext(llvm_ctx), 0, false);
-                }
-            }
-            LLVMTypeRef printf_type = LLVMFunctionType(
-                LLVMInt32TypeInContext(llvm_ctx), NULL, 0, true);
-            LLVMBuildCall2(llvm_builder, printf_type, printf_fn, call_args,
-                           arg_count, "printf_call");
-            free(call_args);
-        }
-        return NULL;
-    }
+    if ((args->type == XVR_AST_NODE_COMPOUND && args->compound.count >= 1) ||
+        (args->type == XVR_AST_NODE_FN_COLLECTION &&
+         args->fnCollection.count >= 1)) {
+        const char* format_str = NULL;
+        LLVMValueRef* call_args = NULL;
+        int arg_count = 0;
+        bool has_format_string = false;
 
-    if (args->type == XVR_AST_NODE_FN_COLLECTION) {
-        int arg_count = args->fnCollection.count;
+        Xvr_ASTNode* format_node = NULL;
+        if (args->type == XVR_AST_NODE_COMPOUND) {
+            format_node = &args->compound.nodes[0];
+            arg_count = args->compound.count - 1;
+        } else {
+            format_node = &args->fnCollection.nodes[0];
+            arg_count = args->fnCollection.count - 1;
+        }
+
+        if (format_node && format_node->type == XVR_AST_NODE_LITERAL &&
+            format_node->atomic.literal.type == XVR_LITERAL_STRING) {
+            has_format_string = true;
+            format_str =
+                (const char*)format_node->atomic.literal.as.string.ptr->data;
+        }
+
         if (arg_count > 0) {
-            LLVMValueRef* call_args =
-                (LLVMValueRef*)malloc(sizeof(LLVMValueRef) * arg_count);
+            call_args = (LLVMValueRef*)malloc(sizeof(LLVMValueRef) * arg_count);
             for (int i = 0; i < arg_count; i++) {
-                Xvr_ASTNode* arg = &args->fnCollection.nodes[i];
+                Xvr_ASTNode* arg = NULL;
+                if (args->type == XVR_AST_NODE_COMPOUND) {
+                    arg = &args->compound.nodes[i + 1];
+                } else {
+                    arg = &args->fnCollection.nodes[i + 1];
+                }
                 LLVMValueRef arg_val =
                     Xvr_LLVMExpressionEmitterEmit(emitter, arg);
                 if (arg_val) {
@@ -873,13 +871,143 @@ static LLVMValueRef emit_printf(Xvr_LLVMExpressionEmitter* emitter,
                         LLVMInt32TypeInContext(llvm_ctx), 0, false);
                 }
             }
-            LLVMTypeRef printf_type = LLVMFunctionType(
-                LLVMInt32TypeInContext(llvm_ctx), NULL, 0, true);
-            LLVMBuildCall2(llvm_builder, printf_type, printf_fn, call_args,
-                           arg_count, "printf_call");
+        }
+
+        if (has_format_string && arg_count > 0) {
+            XvrFormatString* fmt = XvrFormatStringParse(format_str, arg_count);
+            if (fmt && fmt->is_valid) {
+                XvrFormatArgType* arg_types = (XvrFormatArgType*)malloc(
+                    sizeof(XvrFormatArgType) * arg_count);
+                for (int i = 0; i < arg_count; i++) {
+                    LLVMValueRef arg_val = call_args[i];
+                    LLVMTypeRef arg_type = LLVMTypeOf(arg_val);
+                    LLVMTypeKind kind = LLVMGetTypeKind(arg_type);
+                    if (kind == LLVMIntegerTypeKind) {
+                        arg_types[i] = XVR_FORMAT_ARG_INT;
+                    } else if (kind == LLVMFloatTypeKind) {
+                        arg_types[i] = XVR_FORMAT_ARG_FLOAT;
+                    } else if (kind == LLVMDoubleTypeKind) {
+                        arg_types[i] = XVR_FORMAT_ARG_DOUBLE;
+                    } else if (kind == LLVMPointerTypeKind) {
+                        arg_types[i] = XVR_FORMAT_ARG_STRING;
+                    } else {
+                        arg_types[i] = XVR_FORMAT_ARG_STRING;
+                    }
+                }
+
+                char* printf_fmt =
+                    XvrFormatStringBuildPrintfFormat(fmt, arg_types, arg_count);
+
+                LLVMValueRef fmt_global = LLVMBuildGlobalStringPtr(
+                    llvm_builder, printf_fmt, "fmt_str");
+
+                LLVMValueRef* all_args = (LLVMValueRef*)malloc(
+                    sizeof(LLVMValueRef) * (arg_count + 1));
+                all_args[0] = fmt_global;
+                for (int i = 0; i < arg_count; i++) {
+                    LLVMValueRef arg = call_args[i];
+                    LLVMTypeRef arg_type = LLVMTypeOf(arg);
+                    if (LLVMGetTypeKind(arg_type) == LLVMFloatTypeKind) {
+                        all_args[i + 1] =
+                            LLVMBuildFPExt(llvm_builder, arg,
+                                           LLVMDoubleTypeInContext(llvm_ctx),
+                                           "float_to_double");
+                    } else {
+                        all_args[i + 1] = arg;
+                    }
+                }
+
+                LLVMTypeRef* param_types =
+                    (LLVMTypeRef*)malloc(sizeof(LLVMTypeRef) * (arg_count + 1));
+                param_types[0] =
+                    LLVMPointerType(LLVMInt8TypeInContext(llvm_ctx), 0);
+                for (int i = 0; i < arg_count; i++) {
+                    LLVMValueRef arg = call_args[i];
+                    LLVMTypeRef arg_type = LLVMTypeOf(arg);
+                    if (LLVMGetTypeKind(arg_type) == LLVMFloatTypeKind) {
+                        param_types[i + 1] = LLVMDoubleTypeInContext(llvm_ctx);
+                    } else {
+                        param_types[i + 1] = arg_type;
+                    }
+                }
+
+                LLVMTypeRef printf_type =
+                    LLVMFunctionType(LLVMInt32TypeInContext(llvm_ctx),
+                                     param_types, arg_count + 1, true);
+                LLVMBuildCall2(llvm_builder, printf_type, printf_fn, all_args,
+                               arg_count + 1, "printf_call");
+
+                free(all_args);
+                free(param_types);
+                free(printf_fmt);
+                free(arg_types);
+                XvrFormatStringFree(fmt);
+            } else {
+                LLVMValueRef fmt_global =
+                    LLVMBuildGlobalStringPtr(llvm_builder, "%s", "fmt_str");
+                LLVMTypeRef printf_type = LLVMFunctionType(
+                    LLVMInt32TypeInContext(llvm_ctx), NULL, 0, true);
+                LLVMBuildCall2(llvm_builder, printf_type, printf_fn,
+                               &fmt_global, 1, "printf_call");
+                if (fmt) {
+                    XvrFormatStringFree(fmt);
+                }
+            }
+        } else {
+            if (arg_count > 0) {
+                LLVMValueRef fmt_global =
+                    LLVMBuildGlobalStringPtr(llvm_builder, "%s", "fmt_str");
+                LLVMValueRef* all_args = (LLVMValueRef*)malloc(
+                    sizeof(LLVMValueRef) * (arg_count + 1));
+                all_args[0] = fmt_global;
+                for (int i = 0; i < arg_count; i++) {
+                    LLVMValueRef arg = call_args[i];
+                    LLVMTypeRef arg_type = LLVMTypeOf(arg);
+                    if (LLVMGetTypeKind(arg_type) == LLVMFloatTypeKind) {
+                        all_args[i + 1] =
+                            LLVMBuildFPExt(llvm_builder, arg,
+                                           LLVMDoubleTypeInContext(llvm_ctx),
+                                           "float_to_double");
+                    } else {
+                        all_args[i + 1] = arg;
+                    }
+                }
+
+                LLVMTypeRef* param_types =
+                    (LLVMTypeRef*)malloc(sizeof(LLVMTypeRef) * (arg_count + 1));
+                param_types[0] =
+                    LLVMPointerType(LLVMInt8TypeInContext(llvm_ctx), 0);
+                for (int i = 0; i < arg_count; i++) {
+                    LLVMValueRef arg = call_args[i];
+                    LLVMTypeRef arg_type = LLVMTypeOf(arg);
+                    if (LLVMGetTypeKind(arg_type) == LLVMFloatTypeKind) {
+                        param_types[i + 1] = LLVMDoubleTypeInContext(llvm_ctx);
+                    } else {
+                        param_types[i + 1] = arg_type;
+                    }
+                }
+
+                LLVMTypeRef printf_type =
+                    LLVMFunctionType(LLVMInt32TypeInContext(llvm_ctx),
+                                     param_types, arg_count + 1, true);
+                LLVMBuildCall2(llvm_builder, printf_type, printf_fn, all_args,
+                               arg_count + 1, "printf_call");
+
+                free(param_types);
+                free(all_args);
+            } else {
+                LLVMValueRef fmt_global = LLVMBuildGlobalStringPtr(
+                    llvm_builder, format_str ? format_str : "%s", "fmt_str");
+                LLVMTypeRef printf_type = LLVMFunctionType(
+                    LLVMInt32TypeInContext(llvm_ctx), NULL, 0, true);
+                LLVMBuildCall2(llvm_builder, printf_type, printf_fn,
+                               &fmt_global, 1, "printf_call");
+            }
+        }
+
+        if (call_args) {
             free(call_args);
         }
-        return NULL;
     }
 
     return NULL;

--- a/src/backend/xvr_llvm_expression_emitter.c
+++ b/src/backend/xvr_llvm_expression_emitter.c
@@ -1029,55 +1029,85 @@ static LLVMValueRef emit_max(Xvr_LLVMExpressionEmitter* emitter,
     LLVMContextRef llvm_ctx = Xvr_LLVMContextGetLLVMContext(emitter->context);
     LLVMBuilderRef llvm_builder = Xvr_LLVMIRBuilderGetLLVMBuilder(builder);
 
-    LLVMValueRef arg_a = NULL;
-    LLVMValueRef arg_b = NULL;
+    int arg_count = 0;
+    LLVMValueRef* args_list = NULL;
 
-    if (args->type == XVR_AST_NODE_COMPOUND && args->compound.count >= 2) {
-        arg_a =
-            Xvr_LLVMExpressionEmitterEmit(emitter, &args->compound.nodes[0]);
-        arg_b =
-            Xvr_LLVMExpressionEmitterEmit(emitter, &args->compound.nodes[1]);
-    } else if (args->type == XVR_AST_NODE_FN_COLLECTION &&
-               args->fnCollection.count >= 2) {
-        arg_a = Xvr_LLVMExpressionEmitterEmit(emitter,
-                                              &args->fnCollection.nodes[0]);
-        arg_b = Xvr_LLVMExpressionEmitterEmit(emitter,
-                                              &args->fnCollection.nodes[1]);
-    }
-
-    if (!arg_a || !arg_b) {
+    if (args->type == XVR_AST_NODE_COMPOUND) {
+        arg_count = args->compound.count;
+        if (arg_count < 1) {
+            Xvr_LLVMContextSetError(emitter->context,
+                                    "max: requires at least one argument");
+            return NULL;
+        }
+        args_list = (LLVMValueRef*)malloc(sizeof(LLVMValueRef) * arg_count);
+        for (int i = 0; i < arg_count; i++) {
+            args_list[i] = Xvr_LLVMExpressionEmitterEmit(
+                emitter, &args->compound.nodes[i]);
+            if (!args_list[i]) {
+                free(args_list);
+                Xvr_LLVMContextSetError(emitter->context,
+                                        "max: invalid argument");
+                return NULL;
+            }
+        }
+    } else if (args->type == XVR_AST_NODE_FN_COLLECTION) {
+        arg_count = args->fnCollection.count;
+        if (arg_count < 1) {
+            Xvr_LLVMContextSetError(emitter->context,
+                                    "max: requires at least one argument");
+            return NULL;
+        }
+        args_list = (LLVMValueRef*)malloc(sizeof(LLVMValueRef) * arg_count);
+        for (int i = 0; i < arg_count; i++) {
+            args_list[i] = Xvr_LLVMExpressionEmitterEmit(
+                emitter, &args->fnCollection.nodes[i]);
+            if (!args_list[i]) {
+                free(args_list);
+                Xvr_LLVMContextSetError(emitter->context,
+                                        "max: invalid argument");
+                return NULL;
+            }
+        }
+    } else {
         Xvr_LLVMContextSetError(emitter->context, "max: invalid arguments");
         return NULL;
     }
 
-    LLVMTypeRef a_type = LLVMTypeOf(arg_a);
-    LLVMTypeRef b_type = LLVMTypeOf(arg_b);
+    LLVMValueRef max_val = args_list[0];
+    LLVMTypeRef max_type = LLVMTypeOf(max_val);
+    LLVMTypeKind max_kind = LLVMGetTypeKind(max_type);
 
-    if (LLVMGetTypeKind(a_type) == LLVMIntegerTypeKind &&
-        LLVMGetTypeKind(b_type) == LLVMIntegerTypeKind) {
-        LLVMValueRef cond =
-            LLVMBuildICmp(llvm_builder, LLVMIntSGT, arg_a, arg_b, "max_cmp");
-        return LLVMBuildSelect(llvm_builder, cond, arg_a, arg_b, "max_result");
+    for (int i = 1; i < arg_count; i++) {
+        LLVMValueRef arg = args_list[i];
+        LLVMTypeRef arg_type = LLVMTypeOf(arg);
+        LLVMTypeKind arg_kind = LLVMGetTypeKind(arg_type);
+
+        LLVMValueRef cond = NULL;
+
+        if (max_kind == LLVMIntegerTypeKind &&
+            arg_kind == LLVMIntegerTypeKind) {
+            cond = LLVMBuildICmp(llvm_builder, LLVMIntSGT, max_val, arg,
+                                 "max_cmp");
+        } else if ((max_kind == LLVMFloatTypeKind &&
+                    arg_kind == LLVMFloatTypeKind) ||
+                   (max_kind == LLVMDoubleTypeKind &&
+                    arg_kind == LLVMDoubleTypeKind)) {
+            cond = LLVMBuildFCmp(llvm_builder, LLVMRealOGT, max_val, arg,
+                                 "max_cmp");
+        } else {
+            free(args_list);
+            Xvr_LLVMContextSetError(emitter->context,
+                                    "max: all arguments must be the same "
+                                    "comparable type (int or float)");
+            return NULL;
+        }
+
+        max_val =
+            LLVMBuildSelect(llvm_builder, cond, max_val, arg, "max_result");
     }
 
-    if (LLVMGetTypeKind(a_type) == LLVMFloatTypeKind &&
-        LLVMGetTypeKind(b_type) == LLVMFloatTypeKind) {
-        LLVMValueRef cond =
-            LLVMBuildFCmp(llvm_builder, LLVMRealOGT, arg_a, arg_b, "max_cmp");
-        return LLVMBuildSelect(llvm_builder, cond, arg_a, arg_b, "max_result");
-    }
-
-    if (LLVMGetTypeKind(a_type) == LLVMDoubleTypeKind &&
-        LLVMGetTypeKind(b_type) == LLVMDoubleTypeKind) {
-        LLVMValueRef cond =
-            LLVMBuildFCmp(llvm_builder, LLVMRealOGT, arg_a, arg_b, "max_cmp");
-        return LLVMBuildSelect(llvm_builder, cond, arg_a, arg_b, "max_result");
-    }
-
-    Xvr_LLVMContextSetError(
-        emitter->context,
-        "max: unsupported type - only int and float are supported");
-    return NULL;
+    free(args_list);
+    return max_val;
 }
 
 /**

--- a/src/backend/xvr_llvm_expression_emitter.c
+++ b/src/backend/xvr_llvm_expression_emitter.c
@@ -493,6 +493,8 @@ static LLVMValueRef emit_binary_op(Xvr_LLVMExpressionEmitter* emitter,
 
 static LLVMValueRef emit_printf(Xvr_LLVMExpressionEmitter* emitter,
                                 Xvr_ASTNode* args);
+static LLVMValueRef emit_max(Xvr_LLVMExpressionEmitter* emitter,
+                             Xvr_ASTNode* args);
 
 LLVMValueRef Xvr_LLVMExpressionEmitterEmitBinary(
     Xvr_LLVMExpressionEmitter* emitter, Xvr_NodeBinary* binary) {
@@ -638,6 +640,10 @@ LLVMValueRef Xvr_LLVMExpressionEmitterEmitBinary(
                             /* This is std::print - route to emit_printf */
                             return emit_printf(emitter,
                                                fn_call_node->fnCall.arguments);
+                        }
+                        if (fn_name && strcmp(fn_name, "max") == 0) {
+                            return emit_max(emitter,
+                                            fn_call_node->fnCall.arguments);
                         }
                     }
                 }
@@ -876,6 +882,67 @@ static LLVMValueRef emit_printf(Xvr_LLVMExpressionEmitter* emitter,
         return NULL;
     }
 
+    return NULL;
+}
+
+static LLVMValueRef emit_max(Xvr_LLVMExpressionEmitter* emitter,
+                             Xvr_ASTNode* args) {
+    if (!emitter || !args) {
+        return NULL;
+    }
+
+    Xvr_LLVMIRBuilder* builder = emitter->builder;
+    LLVMContextRef llvm_ctx = Xvr_LLVMContextGetLLVMContext(emitter->context);
+    LLVMBuilderRef llvm_builder = Xvr_LLVMIRBuilderGetLLVMBuilder(builder);
+
+    LLVMValueRef arg_a = NULL;
+    LLVMValueRef arg_b = NULL;
+
+    if (args->type == XVR_AST_NODE_COMPOUND && args->compound.count >= 2) {
+        arg_a =
+            Xvr_LLVMExpressionEmitterEmit(emitter, &args->compound.nodes[0]);
+        arg_b =
+            Xvr_LLVMExpressionEmitterEmit(emitter, &args->compound.nodes[1]);
+    } else if (args->type == XVR_AST_NODE_FN_COLLECTION &&
+               args->fnCollection.count >= 2) {
+        arg_a = Xvr_LLVMExpressionEmitterEmit(emitter,
+                                              &args->fnCollection.nodes[0]);
+        arg_b = Xvr_LLVMExpressionEmitterEmit(emitter,
+                                              &args->fnCollection.nodes[1]);
+    }
+
+    if (!arg_a || !arg_b) {
+        Xvr_LLVMContextSetError(emitter->context, "max: invalid arguments");
+        return NULL;
+    }
+
+    LLVMTypeRef a_type = LLVMTypeOf(arg_a);
+    LLVMTypeRef b_type = LLVMTypeOf(arg_b);
+
+    if (LLVMGetTypeKind(a_type) == LLVMIntegerTypeKind &&
+        LLVMGetTypeKind(b_type) == LLVMIntegerTypeKind) {
+        LLVMValueRef cond =
+            LLVMBuildICmp(llvm_builder, LLVMIntSGT, arg_a, arg_b, "max_cmp");
+        return LLVMBuildSelect(llvm_builder, cond, arg_a, arg_b, "max_result");
+    }
+
+    if (LLVMGetTypeKind(a_type) == LLVMFloatTypeKind &&
+        LLVMGetTypeKind(b_type) == LLVMFloatTypeKind) {
+        LLVMValueRef cond =
+            LLVMBuildFCmp(llvm_builder, LLVMRealOGT, arg_a, arg_b, "max_cmp");
+        return LLVMBuildSelect(llvm_builder, cond, arg_a, arg_b, "max_result");
+    }
+
+    if (LLVMGetTypeKind(a_type) == LLVMDoubleTypeKind &&
+        LLVMGetTypeKind(b_type) == LLVMDoubleTypeKind) {
+        LLVMValueRef cond =
+            LLVMBuildFCmp(llvm_builder, LLVMRealOGT, arg_a, arg_b, "max_cmp");
+        return LLVMBuildSelect(llvm_builder, cond, arg_a, arg_b, "max_result");
+    }
+
+    Xvr_LLVMContextSetError(
+        emitter->context,
+        "max: unsupported type - only int and float are supported");
     return NULL;
 }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,7 +21,8 @@ TEST_OBJECTS = $(OBJDIR)/test_all.o \
                $(OBJDIR)/test_literal.o \
                $(OBJDIR)/test_memory.o \
                $(OBJDIR)/test_scope.o \
-               $(OBJDIR)/test_llvm_backend.o
+               $(OBJDIR)/test_llvm_backend.o \
+               $(OBJDIR)/test_std.o
 
 # Compiler tools
 COMPILER_OBJS = ../compiler/compiler_tools.o
@@ -72,6 +73,10 @@ $(OBJDIR)/test_scope.o: test_scope.c
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 $(OBJDIR)/test_llvm_backend.o: test_llvm_backend.c
+	@mkdir -p $(OBJDIR)
+	$(CC) -c $(CFLAGS) -o $@ $<
+
+$(OBJDIR)/test_std.o: test_std.c
 	@mkdir -p $(OBJDIR)
 	$(CC) -c $(CFLAGS) -o $@ $<
 

--- a/test/test_all.c
+++ b/test/test_all.c
@@ -28,6 +28,7 @@ int run_literal_tests(void);
 int run_memory_tests(void);
 int run_ast_node_tests(void);
 int run_llvm_backend_tests(void);
+int run_std_tests(void);
 
 void print_header(const char* title) {
     printf("\n" XVR_CC_NOTICE "  %s\n" XVR_CC_RESET, title);
@@ -117,6 +118,11 @@ int main(void) {
     print_header("LLVM Backend Tests");
     run_test_with_crash_protection("llvm_backend", run_llvm_backend_tests,
                                    "LLVM Backend Infrastructure");
+
+    /* Standard Library Tests */
+    print_header("Standard Library Tests");
+    run_test_with_crash_protection("std_lib", run_std_tests,
+                                   "Standard Library Functions");
 
     /* Summary */
     print_header("TEST SUMMARY");

--- a/test/test_std.c
+++ b/test/test_std.c
@@ -125,6 +125,11 @@ static int run_max_tests(void) {
          "include std;\nvar r = std::max(1.5, 2.5, "
          "0.5);\nstd::print(\"{}\\n\", r);",
          "2.500000", 1},
+        {"max_proc_two_args", "include std;\nstd::max(10, 20);", "", 1},
+        {"max_proc_three_args", "include std;\nstd::max(3, 1, 2);", "", 1},
+        {"max_proc_float", "include std;\nstd::max(1.5, 2.5);", "", 1},
+        {"max_proc_many_args", "include std;\nstd::max(10, 20, 30, 5, 15);", "",
+         1},
     };
 
     int test_count = sizeof(tests) / sizeof(tests[0]);
@@ -134,7 +139,16 @@ static int run_max_tests(void) {
         int status =
             capture_compile_run(tests[i].source, output, sizeof(output));
 
-        if (status == 0 && strcmp(output, tests[i].expected_output) == 0) {
+        int test_passed = 0;
+        if (status == 0) {
+            if (tests[i].expected_output[0] == '\0') {
+                test_passed = 1;
+            } else if (strcmp(output, tests[i].expected_output) == 0) {
+                test_passed = 1;
+            }
+        }
+
+        if (test_passed) {
             printf(XVR_CC_NOTICE "    [PASS] %s\n" XVR_CC_RESET, tests[i].name);
             passed++;
         } else {

--- a/test/test_std.c
+++ b/test/test_std.c
@@ -80,6 +80,9 @@ static int run_max_tests(void) {
     int failed = 0;
 
     StdTestCase tests[] = {
+        {"max_single_arg",
+         "include std;\nvar r = std::max(42);\nstd::print(\"{}\\n\", r);", "42",
+         1},
         {"max_int_greater",
          "include std;\nvar r = std::max(10, 20);\nstd::print(\"{}\\n\", r);",
          "20", 1},
@@ -98,6 +101,13 @@ static int run_max_tests(void) {
         {"max_int_zero",
          "include std;\nvar r = std::max(0, 0);\nstd::print(\"{}\\n\", r);",
          "0", 1},
+        {"max_int_three_args",
+         "include std;\nvar r = std::max(3, 1, 2);\nstd::print(\"{}\\n\", r);",
+         "3", 1},
+        {"max_int_many_args",
+         "include std;\nvar r = std::max(10, 20, 30, 5, "
+         "15);\nstd::print(\"{}\\n\", r);",
+         "30", 1},
         {"max_float_greater",
          "include std;\nvar r = std::max(1.5, 2.5);\nstd::print(\"{}\\n\", r);",
          "2.500000", 1},
@@ -111,6 +121,10 @@ static int run_max_tests(void) {
          "include std;\nvar r = std::max(-1.5, 0.5);\nstd::print(\"{}\\n\", "
          "r);",
          "0.500000", 1},
+        {"max_float_three_args",
+         "include std;\nvar r = std::max(1.5, 2.5, "
+         "0.5);\nstd::print(\"{}\\n\", r);",
+         "2.500000", 1},
     };
 
     int test_count = sizeof(tests) / sizeof(tests[0]);

--- a/test/test_std.c
+++ b/test/test_std.c
@@ -1,0 +1,236 @@
+/**
+ * XVR Standard Library Test Suite
+ * Tests for std::max, std::print and other stdlib functions
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../src/backend/xvr_llvm_codegen.h"
+#include "../src/xvr_ast_node.h"
+#include "../src/xvr_console_colors.h"
+#include "../src/xvr_lexer.h"
+#include "../src/xvr_memory.h"
+#include "../src/xvr_parser.h"
+
+typedef struct {
+    const char* name;
+    const char* source;
+    const char* expected_output;
+    int should_pass;
+} StdTestCase;
+
+typedef struct {
+    const char* name;
+    int (*run)(void);
+} StdTestEntry;
+
+static void normalize_output(char* output) {
+    char* marker = strstr(output, "Compiled to:");
+    if (marker) {
+        *marker = '\0';
+    }
+    size_t len = strlen(output);
+    while (len > 0 && (output[len - 1] == '\n' || output[len - 1] == '\r')) {
+        output[--len] = '\0';
+    }
+}
+
+static int capture_compile_run(const char* source, char* output,
+                               size_t output_size) {
+    FILE* tmp = fopen("/tmp/xvr_std_test.xvr", "w");
+    if (!tmp) return -1;
+    fputs(source, tmp);
+    fclose(tmp);
+
+    char cmd[1024];
+    snprintf(cmd, sizeof(cmd), "./out/xvr /tmp/xvr_std_test.xvr 2>&1");
+
+    FILE* proc = popen(cmd, "r");
+    if (!proc) {
+        unlink("/tmp/xvr_std_test.xvr");
+        return -1;
+    }
+
+    size_t len = fread(output, 1, output_size - 1, proc);
+    output[len] = '\0';
+    int status = pclose(proc);
+
+    unlink("/tmp/xvr_std_test.xvr");
+
+    char* compiled_marker = strstr(output, "Compiled to:");
+    if (compiled_marker) {
+        *compiled_marker = '\0';
+    }
+    size_t out_len = strlen(output);
+    while (out_len > 0 &&
+           (output[out_len - 1] == '\n' || output[out_len - 1] == '\r')) {
+        output[--out_len] = '\0';
+    }
+
+    return status;
+}
+
+static int run_max_tests(void) {
+    printf("\n" XVR_CC_NOTICE "  std::max Tests\n" XVR_CC_RESET);
+
+    int passed = 0;
+    int failed = 0;
+
+    StdTestCase tests[] = {
+        {"max_int_greater",
+         "include std;\nvar r = std::max(10, 20);\nstd::print(\"{}\\n\", r);",
+         "20", 1},
+        {"max_int_less",
+         "include std;\nvar r = std::max(30, 20);\nstd::print(\"{}\\n\", r);",
+         "30", 1},
+        {"max_int_equal",
+         "include std;\nvar r = std::max(5, 5);\nstd::print(\"{}\\n\", r);",
+         "5", 1},
+        {"max_int_negative",
+         "include std;\nvar r = std::max(-10, 5);\nstd::print(\"{}\\n\", r);",
+         "5", 1},
+        {"max_int_both_negative",
+         "include std;\nvar r = std::max(-5, -20);\nstd::print(\"{}\\n\", r);",
+         "-5", 1},
+        {"max_int_zero",
+         "include std;\nvar r = std::max(0, 0);\nstd::print(\"{}\\n\", r);",
+         "0", 1},
+        {"max_float_greater",
+         "include std;\nvar r = std::max(1.5, 2.5);\nstd::print(\"{}\\n\", r);",
+         "2.500000", 1},
+        {"max_float_less",
+         "include std;\nvar r = std::max(3.0, 1.0);\nstd::print(\"{}\\n\", r);",
+         "3.000000", 1},
+        {"max_float_equal",
+         "include std;\nvar r = std::max(1.0, 1.0);\nstd::print(\"{}\\n\", r);",
+         "1.000000", 1},
+        {"max_float_negative",
+         "include std;\nvar r = std::max(-1.5, 0.5);\nstd::print(\"{}\\n\", "
+         "r);",
+         "0.500000", 1},
+    };
+
+    int test_count = sizeof(tests) / sizeof(tests[0]);
+
+    for (int i = 0; i < test_count; i++) {
+        char output[4096] = {0};
+        int status =
+            capture_compile_run(tests[i].source, output, sizeof(output));
+
+        if (status == 0 && strcmp(output, tests[i].expected_output) == 0) {
+            printf(XVR_CC_NOTICE "    [PASS] %s\n" XVR_CC_RESET, tests[i].name);
+            passed++;
+        } else {
+            printf(XVR_CC_ERROR "    [FAIL] %s\n" XVR_CC_RESET, tests[i].name);
+            printf("          expected: '%s', got: '%s'\n",
+                   tests[i].expected_output, output);
+            failed++;
+        }
+    }
+
+    printf("\n  std::max: %d passed, %d failed\n", passed, failed);
+    return failed > 0 ? 1 : 0;
+}
+
+static int run_print_tests(void) {
+    printf("\n" XVR_CC_NOTICE "  std::print Tests\n" XVR_CC_RESET);
+
+    int passed = 0;
+    int failed = 0;
+
+    StdTestCase tests[] = {
+        {"print_int", "include std;\nstd::print(\"{}\\n\", 42);", "42", 1},
+        {"print_negative_int", "include std;\nstd::print(\"{}\\n\", -123);",
+         "-123", 1},
+        {"print_float", "include std;\nstd::print(\"{}\\n\", 3.14);",
+         "3.140000", 1},
+        {"print_string", "include std;\nstd::print(\"{}\\n\", \"hello\");",
+         "hello", 1},
+        {"print_multiple_args",
+         "include std;\nstd::print(\"a: {} b: {}\\n\", 1, 2);", "a: 1 b: 2", 1},
+        {"print_no_args", "include std;\nstd::print(\"hello world\\n\");",
+         "hello world", 1},
+        {"print_zero", "include std;\nstd::print(\"{}\\n\", 0);", "0", 1},
+        {"print_large_number", "include std;\nstd::print(\"{}\\n\", 999999);",
+         "999999", 1},
+    };
+
+    int test_count = sizeof(tests) / sizeof(tests[0]);
+
+    for (int i = 0; i < test_count; i++) {
+        char output[4096] = {0};
+        int status =
+            capture_compile_run(tests[i].source, output, sizeof(output));
+
+        if (status == 0 && strcmp(output, tests[i].expected_output) == 0) {
+            printf(XVR_CC_NOTICE "    [PASS] %s\n" XVR_CC_RESET, tests[i].name);
+            passed++;
+        } else {
+            printf(XVR_CC_ERROR "    [FAIL] %s\n" XVR_CC_RESET, tests[i].name);
+            printf("          expected: '%s', got: '%s'\n",
+                   tests[i].expected_output, output);
+            failed++;
+        }
+    }
+
+    printf("\n  std::print: %d passed, %d failed\n", passed, failed);
+    return failed > 0 ? 1 : 0;
+}
+
+static int run_format_string_tests(void) {
+    printf("\n" XVR_CC_NOTICE "  Format String Tests\n" XVR_CC_RESET);
+
+    int passed = 0;
+    int failed = 0;
+
+    StdTestCase tests[] = {
+        {"format_mixed_int_float",
+         "include std;\nstd::print(\"int: {} float: {}\\n\", 42, 3.14);",
+         "int: 42 float: 3.140000", 1},
+        {"format_many_args",
+         "include std;\nstd::print(\"{} {} {} {}\\n\", 1, 2, 3, 4);", "1 2 3 4",
+         1},
+        {"format_empty_placeholder",
+         "include std;\nstd::print(\"value: {}\\n\", 0);", "value: 0", 1},
+    };
+
+    int test_count = sizeof(tests) / sizeof(tests[0]);
+
+    for (int i = 0; i < test_count; i++) {
+        char output[4096] = {0};
+        int status =
+            capture_compile_run(tests[i].source, output, sizeof(output));
+
+        if (status == 0 && strcmp(output, tests[i].expected_output) == 0) {
+            printf(XVR_CC_NOTICE "    [PASS] %s\n" XVR_CC_RESET, tests[i].name);
+            passed++;
+        } else {
+            printf(XVR_CC_ERROR "    [FAIL] %s\n" XVR_CC_RESET, tests[i].name);
+            printf("          expected: '%s', got: '%s'\n",
+                   tests[i].expected_output, output);
+            failed++;
+        }
+    }
+
+    printf("\n  Format strings: %d passed, %d failed\n", passed, failed);
+    return failed > 0 ? 1 : 0;
+}
+
+int run_std_tests(void) {
+    printf("\n" XVR_CC_NOTICE
+           "===============================================\n" XVR_CC_RESET);
+    printf(XVR_CC_NOTICE "  XVR Standard Library Test Suite\n" XVR_CC_RESET);
+    printf(XVR_CC_NOTICE
+           "===============================================\n" XVR_CC_RESET);
+
+    int total_failed = 0;
+
+    total_failed += run_max_tests();
+    total_failed += run_print_tests();
+    total_failed += run_format_string_tests();
+
+    return total_failed;
+}


### PR DESCRIPTION
### ``std::max()``
Returns the greater of two values:
```xvr
var a = std::max(10, 20);    // a = 20
var b = std::max(5, 5);      // b = 5 (returns first if equal)
var c = std::max(-5, 10);    // c = 10
var d = std::max(1.5, 2.5);  // d = 2.5 (works with floats)
```
Supported types:
- `int` - Integer values
- `float` - Single precision floating point
- `double` - Double precision floating point