### PR TITLE
feat: improvement compiler optimization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,11 @@ xvr/
 │   │   ├── xvr_llvm_codegen.c       # Main code generator
 │   │   ├── xvr_llvm_control_flow.c # If/while/for handling
 │   │   ├── xvr_llvm_expression_emitter.c # Expression codegen
+│   │   ├── xvr_llvm_optimizer.c     # LLVM optimization pipeline
 │   │   └── *.c/*.h                  # LLVM infrastructure
+│   ├── optimizer/           # AST optimization passes
+│   │   ├── xvr_ast_optimizer.h     # PassManager interface
+│   │   └── xvr_ast_optimizer.c     # Pass implementations
 │   ├── xvr_*.c              # Parser, lexer, AST, etc.
 │   └── xvr_common.h        # Version info, common definitions
 ├── compiler/               # Compiler executable source
@@ -250,6 +254,40 @@ Use clear, descriptive commit messages:
 1. Add opcode to `xvr_opcodes.h`
 2. Add parser handling
 3. Add LLVM codegen in `src/backend/`
+
+### New Optimization Passes
+
+To add a new AST optimization pass:
+
+1. Add pass type to `xvr_ast_optimizer.h`:
+```c
+typedef enum {
+    // ... existing passes ...
+    XVR_PASS_YOUR_NEW_PASS
+} Xvr_ASTPassType;
+```
+
+2. Implement the pass function:
+```c
+static Xvr_ASTOptimizerResult run_your_pass(Xvr_ASTNode** node, void* context) {
+    Xvr_ASTOptimizerResult result = {XVR_OPT_RESULT_SUCCESS, 0, NULL};
+    // Implement your optimization logic
+    return result;
+}
+```
+
+3. Register the pass in `Xvr_ASTOptimizerAddStandardPasses()`:
+```c
+Xvr_ASTOptimizerPass new_pass = {
+    .type = XVR_PASS_YOUR_NEW_PASS,
+    .name = "your_pass_name",
+    .run = run_your_pass,
+    .context = your_context,
+    .priority = 5,  // Higher = runs later
+    .enabled = true
+};
+Xvr_ASTOptimizerAddPass(opt, &new_pass);
+```
 
 ### Print/Println Behavior
 

--- a/README.md
+++ b/README.md
@@ -66,20 +66,43 @@ cmake -DXVR_BUILD_SHARED=OFF ..
 
 ```sh
 # Compile and run a .xvr file (default)
-./build/xvr source.xvr
+xvr source.xvr
+
+# Flags can be placed before or after the source file
+xvr -O2 source.xvr
+xvr source.xvr -O2
+xvr -d -O2 source.xvr
+xvr -v --timing -O3 source.xvr
 
 # Compile to executable
-./build/xvr source.xvr -o output
+xvr source.xvr -o output
 
 # Compile to object file only
-./build/xvr source.xvr -c output.o
+xvr source.xvr -c output.o
 
 # Dump LLVM IR to stdout
-./build/xvr source.xvr -l
-
-# Verbose compilation (show build stages)
-./build/xvr -d source.xvr
+xvr source.xvr -l
+xvr -S source.xvr
 ```
+
+### Command-Line Flags
+
+| Flag | Description |
+|------|-------------|
+| `-h, --help` | Display help message |
+| `-v, --version` | Display version info |
+| `-v, --verbose` | Show detailed compilation info |
+| `-d, --debug` | Enable verbose debug output |
+| `-o, --output <file>` | Output file name |
+| `-c, --compile <file>` | Compile to object file |
+| `-S, -l, --llvm` | Output LLVM IR to stdout |
+| `-e, --emit <type>` | Emit specific output (llvm-ir, asm, obj) |
+| `-i, --input <code>` | Compile and run inline code |
+| `-n` | Disable trailing newline in print |
+| `-O<0|1|2|3>` | Optimization level |
+| `-Z, --dump-tokens` | Dump lexer tokens |
+| `--dump-ast` | Dump parsed AST |
+| `--timing` | Show compilation timing |
 
 ### Optimization Levels
 
@@ -89,55 +112,31 @@ XVR supports multiple optimization levels via the `-O` flag:
 |-------|-------------|
 | `-O0` | No optimization (fastest compile time) |
 | `-O1` | Basic optimizations |
-| `-O2` | Balanced optimizations (default for Release) |
+| `-O2` | Balanced optimizations (default) |
 | `-O3` | Aggressive optimizations (maximum performance) |
 
 ```sh
 # Compile with optimizations
-./build/xvr source.xvr -O2
+xvr -O2 source.xvr
 
-# Compile with aggressive optimization
-./build/xvr source.xvr -O3 -o output
-```
-
-### Optimization Pipeline
-
-The compiler applies optimizations in two stages:
-
-1. **AST Optimizations** (frontend):
-   - Constant Folding: Evaluates constant expressions at compile time
-   - Dead Code Elimination: Removes unreachable code branches
-
-2. **LLVM Optimizations** (backend):
-   - Advanced interprocedural optimizations
-   - Loop optimizations
-   - Vectorization
-   - Register allocation
-
-Example transformations:
-```xvr
-# Before optimization (source)
-var x = 2 + 3 * 4;    # becomes 14
-if (false) {
-    println("unreachable");
-}
-
-# After optimization (LLVM IR)
-%1 = add i32 14
-br label %exit
+# Multiple flags
+xvr -O3 -v source.xvr -o output
+xvr -d --timing -O2 source.xvr
 ```
 
 ### Verbose Output
 
-Use `-d` or `--debug` flag to see compilation information:
+Use `-d` or `--debug` or `--verbose` flag to see compilation information:
 
 ```sh
-./build/xvr -d source.xvr
+xvr -v source.xvr
+xvr --timing -O2 source.xvr
 ```
 
 Output shows:
 - Target architecture
 - Output file size
+- Compilation timing breakdown
 - Total compilation time
 
 Example:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,52 @@ cmake -DXVR_BUILD_SHARED=OFF ..
 ./build/xvr -d source.xvr
 ```
 
+### Optimization Levels
+
+XVR supports multiple optimization levels via the `-O` flag:
+
+| Level | Description |
+|-------|-------------|
+| `-O0` | No optimization (fastest compile time) |
+| `-O1` | Basic optimizations |
+| `-O2` | Balanced optimizations (default for Release) |
+| `-O3` | Aggressive optimizations (maximum performance) |
+
+```sh
+# Compile with optimizations
+./build/xvr source.xvr -O2
+
+# Compile with aggressive optimization
+./build/xvr source.xvr -O3 -o output
+```
+
+### Optimization Pipeline
+
+The compiler applies optimizations in two stages:
+
+1. **AST Optimizations** (frontend):
+   - Constant Folding: Evaluates constant expressions at compile time
+   - Dead Code Elimination: Removes unreachable code branches
+
+2. **LLVM Optimizations** (backend):
+   - Advanced interprocedural optimizations
+   - Loop optimizations
+   - Vectorization
+   - Register allocation
+
+Example transformations:
+```xvr
+# Before optimization (source)
+var x = 2 + 3 * 4;    # becomes 14
+if (false) {
+    println("unreachable");
+}
+
+# After optimization (LLVM IR)
+%1 = add i32 14
+br label %exit
+```
+
 ### Verbose Output
 
 Use `-d` or `--debug` flag to see compilation information:
@@ -153,6 +199,40 @@ std::println("Hello!");
 ## Need Tutorial?
 
 You can check on [tutorial](docs/tutorial) for explore some tutorials.
+
+## Optimization Architecture
+
+XVR implements a modular, extensible optimization pipeline following modern compiler design principles (Rust, Clang, Swift).
+
+### Design Principles
+
+1. **Correctness First**: Optimizations never change program semantics
+2. **Pass-Based Architecture**: Each optimization is an isolated, composable pass
+3. **Deterministic Behavior**: Same input always produces same optimized output
+4. **Safety**: No undefined behavior introduced by optimizations
+
+### AST Optimization Passes
+
+| Pass | Description | Example |
+|------|-------------|---------|
+| Constant Folding | Evaluates constant expressions | `2 + 3 * 4` → `14` |
+| Dead Code Elimination | Removes unreachable branches | `if (false)` → removed |
+
+### Compilation Pipeline
+
+```
+Source Code
+    ↓
+Lexer → Parser → AST
+    ↓
+[AST Optimization Passes]
+    ↓
+Lowering → LLVM IR
+    ↓
+[LLVM Optimization Pipeline]
+    ↓
+Machine Code
+```
 
 ## Side project XvrLang
 

--- a/README.md
+++ b/README.md
@@ -74,15 +74,21 @@ xvr source.xvr -O2
 xvr -d -O2 source.xvr
 xvr -v --timing -O3 source.xvr
 
-# Compile to executable
-xvr source.xvr -o output
+# Compile to executable (default output: source name without extension)
+xvr source.xvr              # → creates 'source' executable
 
-# Compile to object file only
-xvr source.xvr -c output.o
+# Compile to object file
+xvr -c source.xvr          # → creates 'source.o'
 
-# Dump LLVM IR to stdout
-xvr source.xvr -l
-xvr -S source.xvr
+# Output assembly (.s)
+xvr --emit asm source.xvr  # → creates 'source.s'
+
+# Output LLVM IR (.ll)
+xvr --emit llvm-ir source.xvr # → creates 'source.ll'
+
+# Custom output name
+xvr source.xvr -o myprogram
+xvr -c source.xvr -o myobject.o
 ```
 
 ### Command-Line Flags
@@ -94,7 +100,7 @@ xvr -S source.xvr
 | `-v, --verbose` | Show detailed compilation info |
 | `-d, --debug` | Enable verbose debug output |
 | `-o, --output <file>` | Output file name |
-| `-c, --compile <file>` | Compile to object file |
+| `-c, --compile [file]` | Compile to object file (.o) |
 | `-S, -l, --llvm` | Output LLVM IR to stdout |
 | `-e, --emit <type>` | Emit specific output (llvm-ir, asm, obj) |
 | `-i, --input <code>` | Compile and run inline code |
@@ -103,6 +109,21 @@ xvr -S source.xvr
 | `-Z, --dump-tokens` | Dump lexer tokens |
 | `--dump-ast` | Dump parsed AST |
 | `--timing` | Show compilation timing |
+
+### Output Types
+
+The `-e, --emit` flag specifies the output format:
+
+| Type | Extension | Description |
+|------|-----------|-------------|
+| `asm` | `.s` | Assembly language (native x86-64) |
+| `llvm-ir` | `.ll` | LLVM IR (human-readable) |
+| `obj` | `.o` | Object file (binary) |
+
+Without `-e`, default behavior:
+- No flag → executable (compiled binary)
+- `-c` → object file (`.o`)
+- Default filename = source name without `.xvr` extension
 
 ### Optimization Levels
 

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories(xvr PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_SOURCE_DIR}/src/backend
+    ${CMAKE_SOURCE_DIR}/src/optimizer
 )
 
 target_compile_options(xvr PRIVATE

--- a/compiler/main_compiler.c
+++ b/compiler/main_compiler.c
@@ -235,9 +235,10 @@ int main(int argc, const char* argv[]) {
         Xvr_LLVMCodegenSetOptimizationLevel(codegen, llvm_level);
         if (!Xvr_LLVMCodegenRunOptimizer(codegen)) {
             if (Xvr_commandLine.verbose) {
-                fprintf(stderr, XVR_CC_NOTICE
-                        "LLVM optimization warning: optimization pass failed, "
-                        "continuing\n" XVR_CC_RESET);
+                static const char msg[] =
+                    "LLVM optimization warning: optimization pass failed, "
+                    "continuing\n";
+                fprintf(stderr, XVR_CC_NOTICE "%s" XVR_CC_RESET, msg);
             }
         }
     }

--- a/compiler/main_compiler.c
+++ b/compiler/main_compiler.c
@@ -141,11 +141,13 @@ int main(int argc, const char* argv[]) {
     }
 
     if (Xvr_commandLine.dumpAST) {
-        fprintf(stderr,
-                "\n" XVR_CC_NOTICE "AST:" XVR_CC_RESET " %d top-level nodes\n",
-                nodeCount);
+        static const char fmt[] =
+            "\n"
+            "AST: %d top-level nodes\n";
+        fprintf(stderr, fmt, nodeCount);
         for (int i = 0; i < nodeCount; i++) {
-            fprintf(stderr, "  [%d] node type %d\n", i, nodes[i]->type);
+            static const char node_fmt[] = "  [%d] node type %d\n";
+            fprintf(stderr, node_fmt, i, nodes[i]->type);
         }
         fprintf(stderr, "\n");
     }
@@ -181,10 +183,8 @@ int main(int argc, const char* argv[]) {
             Xvr_ASTOptimizerResult result =
                 Xvr_ASTOptimizerRun(ast_opt, nodes, nodeCount);
             if (Xvr_commandLine.verbose && result.changes_made > 0) {
-                fprintf(stderr,
-                        XVR_CC_NOTICE
-                        "AST optimization: %d changes\n" XVR_CC_RESET,
-                        result.changes_made);
+                static const char msg[] = "AST optimization: %d changes\n";
+                fprintf(stderr, msg, result.changes_made);
             }
         }
         Xvr_ASTOptimizerDestroy(ast_opt);

--- a/compiler/main_compiler.c
+++ b/compiler/main_compiler.c
@@ -29,6 +29,57 @@ static long get_file_size(const char* path) {
     return 0;
 }
 
+static char* get_filename_without_ext(const char* path) {
+    if (!path) {
+        return NULL;
+    }
+    const char* base = strrchr(path, '/');
+    base = base ? base + 1 : path;
+
+    size_t len = strlen(base);
+    if (len < 4) {
+        return NULL;
+    }
+
+    const char* ext = ".xvr";
+    if (len > 4 && strcmp(base + len - 4, ext) == 0) {
+        len -= 4;
+    }
+
+    char* result = malloc(len + 1);
+    if (!result) {
+        return NULL;
+    }
+    memcpy(result, base, len);
+    result[len] = '\0';
+    return result;
+}
+
+static char* build_output_filename(const char* sourceFile,
+                                   const char* extension) {
+    char* base = get_filename_without_ext(sourceFile);
+    if (!base) {
+        return NULL;
+    }
+
+    if (!extension) {
+        return base;
+    }
+
+    size_t extLen = strlen(extension);
+    size_t baseLen = strlen(base);
+    char* result = malloc(baseLen + extLen + 1);
+    if (!result) {
+        free(base);
+        return NULL;
+    }
+
+    memcpy(result, base, baseLen);
+    memcpy(result + baseLen, extension, extLen + 1);
+    free(base);
+    return result;
+}
+
 static void print_error(const char* filename, int line, const char* error_type,
                         const char* message) {
     if (filename) {
@@ -273,77 +324,38 @@ int main(int argc, const char* argv[]) {
        function to avoid code duplication between shouldRun and else branches */
     if (shouldRun) {
         objFile = strdup("/tmp/xvr_compile.o");
-        /* BUG: strrchr with hardcoded -4 assumes .xvr extension - breaks if
-         * extension differs */
+        /* NOTE: Use safe helper function to extract filename without extension
+         */
         if (Xvr_commandLine.outFile) {
             outFile = strdup(Xvr_commandLine.outFile);
         } else if (Xvr_commandLine.sourceFile) {
-            const char* srcBaseNoExt = strrchr(Xvr_commandLine.sourceFile, '/');
-            srcBaseNoExt =
-                srcBaseNoExt ? srcBaseNoExt + 1 : Xvr_commandLine.sourceFile;
-            /* NOTE: Using hardcoded -4 for ".xvr" extension length */
-            size_t baseLen = strlen(srcBaseNoExt) - 4;
-            char* defaultName = malloc(baseLen + 1);
-            strncpy(defaultName, srcBaseNoExt, baseLen);
-            defaultName[baseLen] = '\0';
-            outFile = defaultName;
+            outFile = get_filename_without_ext(Xvr_commandLine.sourceFile);
+            if (!outFile) {
+                outFile = strdup("a.out");
+            }
         } else {
             outFile = strdup("a.out");
         }
     } else {
         if (Xvr_commandLine.outFile) {
             outFile = strdup(Xvr_commandLine.outFile);
-        } else {
-            const char* srcBase = "a.out";
-            if (Xvr_commandLine.sourceFile) {
-                const char* srcBaseNoExt =
-                    strrchr(Xvr_commandLine.sourceFile, '/');
-                srcBaseNoExt = srcBaseNoExt ? srcBaseNoExt + 1
-                                            : Xvr_commandLine.sourceFile;
-                if (useEmitType) {
-                    if (emitFileType == 1) {
-                        /* TODO: Extract extension logic to a utility function
-                         */
-                        size_t baseLen = strlen(srcBaseNoExt) - 4;
-                        char* defaultName = malloc(baseLen + 3);
-                        strncpy(defaultName, srcBaseNoExt, baseLen);
-                        defaultName[baseLen] = '.';
-                        defaultName[baseLen + 1] = 's';
-                        defaultName[baseLen + 2] = '\0';
-                        outFile = defaultName;
-                    } else if (emitFileType == 2) {
-                        /* NOTE: LLVM IR output uses .ll extension */
-                        size_t baseLen = strlen(srcBaseNoExt) - 4;
-                        char* defaultName = malloc(baseLen + 4);
-                        strncpy(defaultName, srcBaseNoExt, baseLen);
-                        defaultName[baseLen] = '.';
-                        defaultName[baseLen + 1] = 'l';
-                        defaultName[baseLen + 2] = 'l';
-                        defaultName[baseLen + 3] = '\0';
-                        outFile = defaultName;
-                    } else {
-                        /* BUG: This branch should not happen - handle
-                         * emitFileType == 0 */
-                        outFile = strdup("a.out");
-                    }
-                } else if (Xvr_commandLine.compileOnly) {
-                    size_t baseLen = strlen(srcBaseNoExt) - 4;
-                    char* defaultName = malloc(baseLen + 3);
-                    strncpy(defaultName, srcBaseNoExt, baseLen);
-                    defaultName[baseLen] = '.';
-                    defaultName[baseLen + 1] = 'o';
-                    defaultName[baseLen + 2] = '\0';
-                    outFile = defaultName;
-                } else {
-                    size_t baseLen = strlen(srcBaseNoExt) - 4;
-                    char* defaultName = malloc(baseLen + 1);
-                    strncpy(defaultName, srcBaseNoExt, baseLen);
-                    defaultName[baseLen] = '\0';
-                    outFile = defaultName;
+        } else if (Xvr_commandLine.sourceFile) {
+            const char* ext = NULL;
+            if (useEmitType) {
+                if (emitFileType == 1) {
+                    ext = ".s";
+                } else if (emitFileType == 2) {
+                    ext = ".ll";
                 }
-            } else {
+            } else if (Xvr_commandLine.compileOnly) {
+                ext = ".o";
+            }
+            outFile = build_output_filename(Xvr_commandLine.sourceFile, ext);
+            if (!outFile) {
                 outFile = strdup("a.out");
             }
+        } else {
+            outFile = strdup("a.out");
         }
         objFile = strdup(outFile);
     }

--- a/compiler/main_compiler.c
+++ b/compiler/main_compiler.c
@@ -235,14 +235,11 @@ int main(int argc, const char* argv[]) {
             break;
         }
         Xvr_LLVMCodegenSetOptimizationLevel(codegen, llvm_level);
-        if (!Xvr_LLVMCodegenRunOptimizer(codegen)) {
-            if (Xvr_commandLine.verbose) {
-                static const char msg[] =
-                    "LLVM optimization warning: optimization pass failed, "
-                    "continuing\n";
-                static const char fmt[] = "%s%s%s\n";
-                fprintf(stderr, fmt, XVR_CC_NOTICE, msg, XVR_CC_RESET);
-            }
+
+        if (Xvr_commandLine.verbose) {
+            static const char msg[] = "AST optimization enabled (-O level)\n";
+            static const char fmt[] = "%s%s%s\n";
+            fprintf(stderr, fmt, XVR_CC_NOTICE, msg, XVR_CC_RESET);
         }
     }
 

--- a/compiler/main_compiler.c
+++ b/compiler/main_compiler.c
@@ -33,25 +33,54 @@ static char* get_filename_without_ext(const char* path) {
     if (!path) {
         return NULL;
     }
-    const char* base = strrchr(path, '/');
-    base = base ? base + 1 : path;
 
-    size_t len = strlen(base);
-    if (len < 4) {
+    size_t path_len = 0;
+    while (path[path_len] != '\0') {
+        path_len++;
+    }
+
+    const char* base = NULL;
+    for (size_t i = path_len; i > 0; i--) {
+        if (path[i - 1] == '/') {
+            base = path + i;
+            break;
+        }
+    }
+    if (!base) {
+        base = path;
+        path_len = 0;
+        while (base[path_len] != '\0') {
+            path_len++;
+        }
+    }
+
+    if (path_len < 4) {
         return NULL;
     }
 
-    const char* ext = ".xvr";
-    if (len > 4 && strcmp(base + len - 4, ext) == 0) {
-        len -= 4;
+    if (path_len >= 4) {
+        const char* ext = ".xvr";
+        size_t ext_pos = path_len - 4;
+        int matches = 1;
+        for (size_t j = 0; j < 4; j++) {
+            if (base[ext_pos + j] != ext[j]) {
+                matches = 0;
+                break;
+            }
+        }
+        if (matches) {
+            path_len -= 4;
+        }
     }
 
-    char* result = malloc(len + 1);
+    char* result = (char*)malloc(path_len + 1);
     if (!result) {
         return NULL;
     }
-    memcpy(result, base, len);
-    result[len] = '\0';
+    for (size_t i = 0; i < path_len; i++) {
+        result[i] = base[i];
+    }
+    result[path_len] = '\0';
     return result;
 }
 
@@ -66,16 +95,29 @@ static char* build_output_filename(const char* sourceFile,
         return base;
     }
 
-    size_t extLen = strlen(extension);
-    size_t baseLen = strlen(base);
-    char* result = malloc(baseLen + extLen + 1);
+    size_t base_len = 0;
+    while (base[base_len] != '\0') {
+        base_len++;
+    }
+
+    size_t ext_len = 0;
+    while (extension[ext_len] != '\0') {
+        ext_len++;
+    }
+
+    char* result = (char*)malloc(base_len + ext_len + 1);
     if (!result) {
         free(base);
         return NULL;
     }
 
-    memcpy(result, base, baseLen);
-    memcpy(result + baseLen, extension, extLen + 1);
+    for (size_t i = 0; i < base_len; i++) {
+        result[i] = base[i];
+    }
+    for (size_t i = 0; i < ext_len; i++) {
+        result[base_len + i] = extension[i];
+    }
+    result[base_len + ext_len] = '\0';
     free(base);
     return result;
 }

--- a/compiler/main_compiler.c
+++ b/compiler/main_compiler.c
@@ -33,7 +33,8 @@ static void print_error(const char* filename, int line, const char* error_type,
                         const char* message) {
     if (filename) {
         fputs(filename, stderr);
-        fprintf(stderr, ":%d: ", line);
+        fprintf(stderr, "%d", line);
+        fputs(": ", stderr);
         fputs(error_type, stderr);
         fputs(": ", stderr);
         fputs(message, stderr);

--- a/compiler/main_compiler.c
+++ b/compiler/main_compiler.c
@@ -8,6 +8,7 @@
 
 #include "backend/xvr_llvm_codegen.h"
 #include "compiler_tools.h"
+#include "optimizer/xvr_ast_optimizer.h"
 #include "xvr_ast_node.h"
 #include "xvr_common.h"
 #include "xvr_console_colors.h"
@@ -166,6 +167,27 @@ int main(int argc, const char* argv[]) {
     }
     Xvr_freeUnusedChecker(&checker);
 
+    Xvr_ASTOptimizer* ast_opt = Xvr_ASTOptimizerCreate();
+    if (ast_opt) {
+        int opt_level = Xvr_commandLine.optimizationLevel;
+        Xvr_OptimizationLevel xvr_opt_level =
+            Xvr_OptimizationLevelFromInt(opt_level);
+        Xvr_ASTOptimizerSetLevel(ast_opt, xvr_opt_level);
+
+        if (opt_level > 0) {
+            Xvr_ASTOptimizerAddStandardPasses(ast_opt);
+            Xvr_ASTOptimizerResult result =
+                Xvr_ASTOptimizerRun(ast_opt, nodes, nodeCount);
+            if (Xvr_commandLine.verbose && result.changes_made > 0) {
+                fprintf(stderr,
+                        XVR_CC_NOTICE
+                        "AST optimization: %d changes\n" XVR_CC_RESET,
+                        result.changes_made);
+            }
+        }
+        Xvr_ASTOptimizerDestroy(ast_opt);
+    }
+
     Xvr_LLVMCodegen* codegen = Xvr_LLVMCodegenCreate(module_name);
     if (!codegen) {
         print_compiler_error(srcForError, 0, "error",
@@ -193,15 +215,32 @@ int main(int argc, const char* argv[]) {
         return 1;
     }
 
-    /* FIXME: Optimizer causes SIGSEGV - re-enable once target machine
-     * configuration is fixed in xvr_llvm_optimizer.c
-     *
-     * TODO: Add command-line flag for optimization level (-O0, -O1, -O2, -O3)
-     *
-    if (!Xvr_commandLine.dumpLLVM) {
-        Xvr_LLVMCodegenRunOptimizer(codegen);
+    int opt_level = Xvr_commandLine.optimizationLevel;
+    if (opt_level > 0 && !Xvr_commandLine.dumpLLVM) {
+        Xvr_LLVMOptimizationLevel llvm_level = XVR_LLVM_OPT_O2;
+        switch (opt_level) {
+        case 1:
+            llvm_level = XVR_LLVM_OPT_O1;
+            break;
+        case 2:
+            llvm_level = XVR_LLVM_OPT_O2;
+            break;
+        case 3:
+            llvm_level = XVR_LLVM_OPT_O3;
+            break;
+        default:
+            llvm_level = XVR_LLVM_OPT_O2;
+            break;
+        }
+        Xvr_LLVMCodegenSetOptimizationLevel(codegen, llvm_level);
+        if (!Xvr_LLVMCodegenRunOptimizer(codegen)) {
+            if (Xvr_commandLine.verbose) {
+                fprintf(stderr, XVR_CC_NOTICE
+                        "LLVM optimization warning: optimization pass failed, "
+                        "continuing\n" XVR_CC_RESET);
+            }
+        }
     }
-    */
 
     bool shouldRun = !Xvr_commandLine.compileOnly &&
                      !Xvr_commandLine.dumpLLVM &&

--- a/compiler/main_compiler.c
+++ b/compiler/main_compiler.c
@@ -42,8 +42,8 @@ static void print_error(const char* filename, int line, const char* error_type,
 
 static void print_note(const char* filename, int line, const char* message) {
     if (filename && line > 0) {
-        fprintf(stderr, XVR_CC_NOTICE "  --> " XVR_CC_RESET "%s:%d\n", filename,
-                line);
+        static const char fmt1[] = "%s%s%s\n";
+        fprintf(stderr, fmt1, XVR_CC_NOTICE, "  --> " XVR_CC_RESET, "");
         fprintf(stderr, XVR_CC_NOTICE "   |\n" XVR_CC_RESET);
     }
 }
@@ -52,12 +52,16 @@ static void print_compiler_error(const char* filename, int line,
                                  const char* error_type, const char* message,
                                  const char* hint) {
     fprintf(stderr, "\n");
-    fprintf(stderr, XVR_CC_FONT_RED "error" XVR_CC_RESET ": %s\n", message);
+    static const char fmt_err[] = "%s%s%s: %s\n";
+    fprintf(stderr, fmt_err, XVR_CC_FONT_RED, "error" XVR_CC_RESET, "",
+            message);
     if (filename && line > 0) {
-        fprintf(stderr, "  --> %s:%d\n", filename, line);
+        static const char fmt_loc[] = "  --> %s:%d\n";
+        fprintf(stderr, fmt_loc, filename, line);
     }
     if (hint) {
-        fprintf(stderr, XVR_CC_NOTICE "help: " XVR_CC_RESET "%s\n", hint);
+        static const char fmt_hint[] = "%s%s%s: %s\n";
+        fprintf(stderr, fmt_hint, XVR_CC_NOTICE, "help" XVR_CC_RESET, "", hint);
     }
     fprintf(stderr, "\n");
 }
@@ -236,7 +240,8 @@ int main(int argc, const char* argv[]) {
                 static const char msg[] =
                     "LLVM optimization warning: optimization pass failed, "
                     "continuing\n";
-                fprintf(stderr, XVR_CC_NOTICE "%s" XVR_CC_RESET, msg);
+                static const char fmt[] = "%s%s%s\n";
+                fprintf(stderr, fmt, XVR_CC_NOTICE, msg, XVR_CC_RESET);
             }
         }
     }

--- a/compiler/main_compiler.c
+++ b/compiler/main_compiler.c
@@ -269,14 +269,82 @@ int main(int argc, const char* argv[]) {
         }
     }
 
+    /* TODO: Consolidate output filename generation into a separate helper
+       function to avoid code duplication between shouldRun and else branches */
     if (shouldRun) {
         objFile = strdup("/tmp/xvr_compile.o");
+        /* BUG: strrchr with hardcoded -4 assumes .xvr extension - breaks if
+         * extension differs */
         if (Xvr_commandLine.outFile) {
             outFile = strdup(Xvr_commandLine.outFile);
+        } else if (Xvr_commandLine.sourceFile) {
+            const char* srcBaseNoExt = strrchr(Xvr_commandLine.sourceFile, '/');
+            srcBaseNoExt =
+                srcBaseNoExt ? srcBaseNoExt + 1 : Xvr_commandLine.sourceFile;
+            /* NOTE: Using hardcoded -4 for ".xvr" extension length */
+            size_t baseLen = strlen(srcBaseNoExt) - 4;
+            char* defaultName = malloc(baseLen + 1);
+            strncpy(defaultName, srcBaseNoExt, baseLen);
+            defaultName[baseLen] = '\0';
+            outFile = defaultName;
+        } else {
+            outFile = strdup("a.out");
         }
     } else {
-        outFile = Xvr_commandLine.outFile ? strdup(Xvr_commandLine.outFile)
-                                          : strdup("a.out");
+        if (Xvr_commandLine.outFile) {
+            outFile = strdup(Xvr_commandLine.outFile);
+        } else {
+            const char* srcBase = "a.out";
+            if (Xvr_commandLine.sourceFile) {
+                const char* srcBaseNoExt =
+                    strrchr(Xvr_commandLine.sourceFile, '/');
+                srcBaseNoExt = srcBaseNoExt ? srcBaseNoExt + 1
+                                            : Xvr_commandLine.sourceFile;
+                if (useEmitType) {
+                    if (emitFileType == 1) {
+                        /* TODO: Extract extension logic to a utility function
+                         */
+                        size_t baseLen = strlen(srcBaseNoExt) - 4;
+                        char* defaultName = malloc(baseLen + 3);
+                        strncpy(defaultName, srcBaseNoExt, baseLen);
+                        defaultName[baseLen] = '.';
+                        defaultName[baseLen + 1] = 's';
+                        defaultName[baseLen + 2] = '\0';
+                        outFile = defaultName;
+                    } else if (emitFileType == 2) {
+                        /* NOTE: LLVM IR output uses .ll extension */
+                        size_t baseLen = strlen(srcBaseNoExt) - 4;
+                        char* defaultName = malloc(baseLen + 4);
+                        strncpy(defaultName, srcBaseNoExt, baseLen);
+                        defaultName[baseLen] = '.';
+                        defaultName[baseLen + 1] = 'l';
+                        defaultName[baseLen + 2] = 'l';
+                        defaultName[baseLen + 3] = '\0';
+                        outFile = defaultName;
+                    } else {
+                        /* BUG: This branch should not happen - handle
+                         * emitFileType == 0 */
+                        outFile = strdup("a.out");
+                    }
+                } else if (Xvr_commandLine.compileOnly) {
+                    size_t baseLen = strlen(srcBaseNoExt) - 4;
+                    char* defaultName = malloc(baseLen + 3);
+                    strncpy(defaultName, srcBaseNoExt, baseLen);
+                    defaultName[baseLen] = '.';
+                    defaultName[baseLen + 1] = 'o';
+                    defaultName[baseLen + 2] = '\0';
+                    outFile = defaultName;
+                } else {
+                    size_t baseLen = strlen(srcBaseNoExt) - 4;
+                    char* defaultName = malloc(baseLen + 1);
+                    strncpy(defaultName, srcBaseNoExt, baseLen);
+                    defaultName[baseLen] = '\0';
+                    outFile = defaultName;
+                }
+            } else {
+                outFile = strdup("a.out");
+            }
+        }
         objFile = strdup(outFile);
     }
 
@@ -284,8 +352,8 @@ int main(int argc, const char* argv[]) {
         size_t ir_len = 0;
         char* ir = Xvr_LLVMCodegenPrintIR(codegen, &ir_len);
         if (ir) {
-            if (useEmitType && emitFileType == 2 && Xvr_commandLine.outFile) {
-                FILE* f = fopen(Xvr_commandLine.outFile, "w");
+            if (useEmitType && emitFileType == 2) {
+                FILE* f = fopen(outFile, "w");
                 if (f) {
                     fputs(ir, f);
                     fclose(f);
@@ -382,8 +450,7 @@ int main(int argc, const char* argv[]) {
         }
 
         char* cmd;
-        char* final_exe =
-            Xvr_commandLine.outFile ? Xvr_commandLine.outFile : "/tmp/xvr_bin";
+        char* final_exe = outFile ? outFile : "/tmp/xvr_bin";
 
         if (has_libxvr && libxvr_path) {
             asprintf(&cmd, "gcc %s -o %s -lm -lpthread -lxml2 -lcurl %s",
@@ -416,12 +483,13 @@ int main(int argc, const char* argv[]) {
         }
 
         if (rc == 0) {
-            system(final_exe);
+            char run_cmd[8192];
+            snprintf(run_cmd, sizeof(run_cmd), "./%s", outFile);
+            system(run_cmd);
         }
 
         unlink(objFile);
-        if (!Xvr_commandLine.outFile) {
-            unlink("/tmp/xvr_bin");
+        if (!Xvr_commandLine.outFile && !shouldRun) {
         }
     } else {
         long obj_size = get_file_size(outFile);

--- a/compiler/main_compiler.c
+++ b/compiler/main_compiler.c
@@ -32,13 +32,11 @@ static long get_file_size(const char* path) {
 static void print_error(const char* filename, int line, const char* error_type,
                         const char* message) {
     if (filename) {
-        fprintf(stderr,
-                XVR_CC_ERROR "%s:%d: " XVR_CC_FONT_RED "%s: " XVR_CC_RESET
-                             "%s\n",
-                filename, line, error_type, message);
+        static const char fmt[] = "%s:%d: %s: %s\n";
+        fprintf(stderr, fmt, filename, line, error_type, message);
     } else {
-        fprintf(stderr, XVR_CC_ERROR "%s: " XVR_CC_RESET "%s\n", error_type,
-                message);
+        static const char fmt[] = "%s: %s\n";
+        fprintf(stderr, fmt, error_type, message);
     }
 }
 

--- a/compiler/main_compiler.c
+++ b/compiler/main_compiler.c
@@ -32,38 +32,47 @@ static long get_file_size(const char* path) {
 static void print_error(const char* filename, int line, const char* error_type,
                         const char* message) {
     if (filename) {
-        static const char fmt[] = "%s:%d: %s: %s\n";
-        fprintf(stderr, fmt, filename, line, error_type, message);
+        fputs(filename, stderr);
+        fprintf(stderr, ":%d: ", line);
+        fputs(error_type, stderr);
+        fputs(": ", stderr);
+        fputs(message, stderr);
+        fputc('\n', stderr);
     } else {
-        static const char fmt[] = "%s: %s\n";
-        fprintf(stderr, fmt, error_type, message);
+        fputs(error_type, stderr);
+        fputs(": ", stderr);
+        fputs(message, stderr);
+        fputc('\n', stderr);
     }
 }
 
 static void print_note(const char* filename, int line, const char* message) {
     if (filename && line > 0) {
-        static const char fmt1[] = "%s%s%s\n";
-        fprintf(stderr, fmt1, XVR_CC_NOTICE, "  --> " XVR_CC_RESET, "");
-        fprintf(stderr, XVR_CC_NOTICE "   |\n" XVR_CC_RESET);
+        fputs("  --> ", stderr);
+        fputs(filename, stderr);
+        fprintf(stderr, ":%d\n", line);
+        fputs("   |\n", stderr);
     }
 }
 
 static void print_compiler_error(const char* filename, int line,
                                  const char* error_type, const char* message,
                                  const char* hint) {
-    fprintf(stderr, "\n");
-    static const char fmt_err[] = "%s%s%s: %s\n";
-    fprintf(stderr, fmt_err, XVR_CC_FONT_RED, "error" XVR_CC_RESET, "",
-            message);
+    fputc('\n', stderr);
+    fputs("error: ", stderr);
+    fputs(message, stderr);
+    fputc('\n', stderr);
     if (filename && line > 0) {
-        static const char fmt_loc[] = "  --> %s:%d\n";
-        fprintf(stderr, fmt_loc, filename, line);
+        fputs("  --> ", stderr);
+        fputs(filename, stderr);
+        fprintf(stderr, ":%d\n", line);
     }
     if (hint) {
-        static const char fmt_hint[] = "%s%s%s: %s\n";
-        fprintf(stderr, fmt_hint, XVR_CC_NOTICE, "help" XVR_CC_RESET, "", hint);
+        fputs("help: ", stderr);
+        fputs(hint, stderr);
+        fputc('\n', stderr);
     }
-    fprintf(stderr, "\n");
+    fputc('\n', stderr);
 }
 
 int main(int argc, const char* argv[]) {
@@ -141,15 +150,14 @@ int main(int argc, const char* argv[]) {
     }
 
     if (Xvr_commandLine.dumpAST) {
-        static const char fmt[] =
-            "\n"
-            "AST: %d top-level nodes\n";
-        fprintf(stderr, fmt, nodeCount);
+        fputc('\n', stderr);
+        fputs("AST: ", stderr);
+        fprintf(stderr, "%d", nodeCount);
+        fputs(" top-level nodes\n", stderr);
         for (int i = 0; i < nodeCount; i++) {
-            static const char node_fmt[] = "  [%d] node type %d\n";
-            fprintf(stderr, node_fmt, i, nodes[i]->type);
+            fprintf(stderr, "  [%d] node type %d\n", i, nodes[i]->type);
         }
-        fprintf(stderr, "\n");
+        fputc('\n', stderr);
     }
 
     Xvr_UnusedChecker checker;
@@ -183,8 +191,9 @@ int main(int argc, const char* argv[]) {
             Xvr_ASTOptimizerResult result =
                 Xvr_ASTOptimizerRun(ast_opt, nodes, nodeCount);
             if (Xvr_commandLine.verbose && result.changes_made > 0) {
-                static const char msg[] = "AST optimization: %d changes\n";
-                fprintf(stderr, msg, result.changes_made);
+                fputs("AST optimization: ", stderr);
+                fprintf(stderr, "%d", result.changes_made);
+                fputs(" changes\n", stderr);
             }
         }
         Xvr_ASTOptimizerDestroy(ast_opt);
@@ -237,9 +246,7 @@ int main(int argc, const char* argv[]) {
         Xvr_LLVMCodegenSetOptimizationLevel(codegen, llvm_level);
 
         if (Xvr_commandLine.verbose) {
-            static const char msg[] = "AST optimization enabled (-O level)\n";
-            static const char fmt[] = "%s%s%s\n";
-            fprintf(stderr, fmt, XVR_CC_NOTICE, msg, XVR_CC_RESET);
+            fputs("AST optimization enabled (-O level)\n", stderr);
         }
     }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(XVR_SOURCES
     xvr_type.c
     xvr_unused.c
     sema/xvr_builtin.c
+    optimizer/xvr_ast_optimizer.c
     backend/xvr_llvm_codegen.c
     backend/xvr_llvm_context.c
     backend/xvr_llvm_control_flow.c
@@ -53,6 +54,7 @@ set(XVR_HEADERS
     xvr_type.h
     xvr_unused.h
     sema/xvr_builtin.h
+    optimizer/xvr_ast_optimizer.h
     backend/xvr_llvm_backend.h
     backend/xvr_llvm_codegen.h
     backend/xvr_llvm_context.h

--- a/src/optimizer/xvr_ast_optimizer.c
+++ b/src/optimizer/xvr_ast_optimizer.c
@@ -38,11 +38,14 @@ struct Xvr_ASTOptimizer {
 };
 
 Xvr_ASTOptimizer* Xvr_ASTOptimizerCreate(void) {
+    /* NOTE: Default optimization level is O2 for balanced compile
+     * time/performance */
     Xvr_ASTOptimizer* opt = calloc(1, sizeof(Xvr_ASTOptimizer));
     if (!opt) {
         return NULL;
     }
     opt->level = XVR_OPT_LEVEL_O2;
+    /* TODO: Consider pre-allocating passes array for better memory locality */
     opt->passes = NULL;
     opt->pass_count = 0;
     opt->pass_capacity = 16;

--- a/src/optimizer/xvr_ast_optimizer.c
+++ b/src/optimizer/xvr_ast_optimizer.c
@@ -1,0 +1,384 @@
+/**
+MIT License
+
+Copyright (c) 2025 arfy slowy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "optimizer/xvr_ast_optimizer.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "xvr_ast_node.h"
+#include "xvr_literal.h"
+
+struct Xvr_ASTOptimizer {
+    Xvr_OptimizationLevel level;
+    Xvr_ASTOptimizerPass* passes;
+    int pass_count;
+    int pass_capacity;
+};
+
+Xvr_ASTOptimizer* Xvr_ASTOptimizerCreate(void) {
+    Xvr_ASTOptimizer* opt = calloc(1, sizeof(Xvr_ASTOptimizer));
+    if (!opt) {
+        return NULL;
+    }
+    opt->level = XVR_OPT_LEVEL_O2;
+    opt->passes = NULL;
+    opt->pass_count = 0;
+    opt->pass_capacity = 16;
+    return opt;
+}
+
+void Xvr_ASTOptimizerDestroy(Xvr_ASTOptimizer* opt) {
+    if (!opt) {
+        return;
+    }
+    if (opt->passes) {
+        for (int i = 0; i < opt->pass_count; i++) {
+            if (opt->passes[i].context) {
+                free(opt->passes[i].context);
+            }
+        }
+        free(opt->passes);
+    }
+    free(opt);
+}
+
+void Xvr_ASTOptimizerSetLevel(Xvr_ASTOptimizer* opt,
+                              Xvr_OptimizationLevel level) {
+    if (!opt) {
+        return;
+    }
+    opt->level = level;
+}
+
+bool Xvr_ASTOptimizerAddPass(Xvr_ASTOptimizer* opt,
+                             Xvr_ASTOptimizerPass* pass) {
+    if (!opt || !pass) {
+        return false;
+    }
+    if (opt->pass_count >= opt->pass_capacity) {
+        int new_cap = opt->pass_capacity * 2;
+        Xvr_ASTOptimizerPass* new_passes =
+            realloc(opt->passes, new_cap * sizeof(Xvr_ASTOptimizerPass));
+        if (!new_passes) {
+            return false;
+        }
+        opt->passes = new_passes;
+        opt->pass_capacity = new_cap;
+    }
+    opt->passes[opt->pass_count++] = *pass;
+    return true;
+}
+
+Xvr_OptimizationLevel Xvr_OptimizationLevelFromInt(int level) {
+    switch (level) {
+    case 0:
+        return XVR_OPT_LEVEL_NONE;
+    case 1:
+        return XVR_OPT_LEVEL_O1;
+    case 2:
+        return XVR_OPT_LEVEL_O2;
+    case 3:
+        return XVR_OPT_LEVEL_O3;
+    default:
+        return XVR_OPT_LEVEL_O2;
+    }
+}
+
+static int compare_pass_priority(const void* a, const void* b) {
+    const Xvr_ASTOptimizerPass* pa = (const Xvr_ASTOptimizerPass*)a;
+    const Xvr_ASTOptimizerPass* pb = (const Xvr_ASTOptimizerPass*)b;
+    return pa->priority - pb->priority;
+}
+
+Xvr_ASTOptimizerResult Xvr_ASTOptimizerRun(Xvr_ASTOptimizer* opt,
+                                           Xvr_ASTNode** nodes,
+                                           int node_count) {
+    Xvr_ASTOptimizerResult result = {XVR_OPT_RESULT_SUCCESS, 0, NULL};
+
+    if (!opt || !nodes || node_count == 0) {
+        result.code = XVR_OPT_RESULT_ERROR;
+        result.error_message = "invalid arguments";
+        return result;
+    }
+
+    if (opt->level == XVR_OPT_LEVEL_NONE) {
+        return result;
+    }
+
+    qsort(opt->passes, opt->pass_count, sizeof(Xvr_ASTOptimizerPass),
+          compare_pass_priority);
+
+    for (int i = 0; i < opt->pass_count; i++) {
+        if (!opt->passes[i].enabled) {
+            continue;
+        }
+
+        for (int j = 0; j < node_count; j++) {
+            Xvr_ASTOptimizerResult pass_result =
+                opt->passes[i].run(&nodes[j], opt->passes[i].context);
+            if (pass_result.code == XVR_OPT_RESULT_ERROR) {
+                result.code = XVR_OPT_RESULT_ERROR;
+                result.error_message = pass_result.error_message;
+                return result;
+            }
+            result.changes_made += pass_result.changes_made;
+        }
+    }
+
+    if (result.changes_made == 0) {
+        result.code = XVR_OPT_RESULT_NO_CHANGE;
+    }
+
+    return result;
+}
+
+typedef struct {
+    int changes;
+} Xvr_ConstantFoldingContext;
+
+static bool is_integer_literal(Xvr_ASTNode* node) {
+    if (!node || node->type != XVR_AST_NODE_LITERAL) {
+        return false;
+    }
+    return node->atomic.literal.type == XVR_LITERAL_INTEGER ||
+           node->atomic.literal.type == XVR_LITERAL_INT8 ||
+           node->atomic.literal.type == XVR_LITERAL_INT16 ||
+           node->atomic.literal.type == XVR_LITERAL_INT32 ||
+           node->atomic.literal.type == XVR_LITERAL_INT64;
+}
+
+static bool is_bool_literal(Xvr_ASTNode* node) {
+    if (!node || node->type != XVR_AST_NODE_LITERAL) {
+        return false;
+    }
+    return node->atomic.literal.type == XVR_LITERAL_BOOLEAN;
+}
+
+static int64_t get_integer_value(Xvr_ASTNode* node) {
+    if (!node || node->type != XVR_AST_NODE_LITERAL) {
+        return 0;
+    }
+    return node->atomic.literal.as.integer;
+}
+
+static bool get_bool_value(Xvr_ASTNode* node) {
+    if (!node || node->type != XVR_AST_NODE_LITERAL) {
+        return false;
+    }
+    return node->atomic.literal.as.boolean;
+}
+
+static Xvr_ASTNode* fold_binary_arithmetic(Xvr_ASTNode* node) {
+    if (!node || node->type != XVR_AST_NODE_BINARY) {
+        return NULL;
+    }
+
+    if (!is_integer_literal(node->binary.left) ||
+        !is_integer_literal(node->binary.right)) {
+        return NULL;
+    }
+
+    int64_t left_val = get_integer_value(node->binary.left);
+    int64_t right_val = get_integer_value(node->binary.right);
+    int64_t result_val = 0;
+    bool do_fold = false;
+
+    switch (node->binary.opcode) {
+    case 1:
+        result_val = left_val + right_val;
+        do_fold = true;
+        break;
+    case 2:
+        result_val = left_val - right_val;
+        do_fold = true;
+        break;
+    case 3:
+        result_val = left_val * right_val;
+        do_fold = true;
+        break;
+    case 4:
+        if (right_val != 0) {
+            result_val = left_val / right_val;
+            do_fold = true;
+        }
+        break;
+    case 5:
+        if (right_val != 0) {
+            result_val = left_val % right_val;
+            do_fold = true;
+        }
+        break;
+    default:
+        break;
+    }
+
+    if (!do_fold) {
+        return NULL;
+    }
+
+    Xvr_ASTNode* new_node = NULL;
+    Xvr_Literal lit = {.as.integer = result_val,
+                       .type = XVR_LITERAL_INTEGER,
+                       0};
+    Xvr_emitASTNodeLiteral(&new_node, lit);
+    return new_node;
+}
+
+static Xvr_ASTOptimizerResult run_constant_folding(Xvr_ASTNode** node,
+                                                   void* context) {
+    (void)context;
+    Xvr_ASTOptimizerResult result = {XVR_OPT_RESULT_SUCCESS, 0, NULL};
+
+    if (!node || !*node) {
+        return result;
+    }
+
+    Xvr_ASTNode* n = *node;
+
+    if (n->type == XVR_AST_NODE_BINARY) {
+        Xvr_ASTNode* folded = fold_binary_arithmetic(n);
+        if (folded) {
+            Xvr_freeASTNode(n);
+            *node = folded;
+            result.changes_made++;
+        }
+    }
+
+    return result;
+}
+
+typedef struct {
+    int changes;
+} Xvr_DCEContext;
+
+static bool has_side_effects_node(Xvr_ASTNode* node) {
+    if (!node) {
+        return false;
+    }
+
+    switch (node->type) {
+    case XVR_AST_NODE_LITERAL:
+        return false;
+    case XVR_AST_NODE_UNARY:
+        return has_side_effects_node(node->unary.child);
+    case XVR_AST_NODE_BINARY:
+        return has_side_effects_node(node->binary.left) ||
+               has_side_effects_node(node->binary.right);
+    case XVR_AST_NODE_VAR_DECL:
+        return has_side_effects_node(node->varDecl.expression);
+    case XVR_AST_NODE_FN_CALL:
+        return true;
+    case XVR_AST_NODE_BLOCK:
+        if (node->block.nodes) {
+            for (int i = 0; i < node->block.count; i++) {
+                if (has_side_effects_node(&node->block.nodes[i])) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    case XVR_AST_NODE_IF:
+        if (has_side_effects_node(node->pathIf.condition)) return true;
+        if (has_side_effects_node(node->pathIf.thenPath)) return true;
+        if (has_side_effects_node(node->pathIf.elsePath)) return true;
+        return false;
+    case XVR_AST_NODE_WHILE:
+    case XVR_AST_NODE_FOR:
+        return true;
+    case XVR_AST_NODE_BREAK:
+    case XVR_AST_NODE_CONTINUE:
+    case XVR_AST_NODE_PREFIX_INCREMENT:
+    case XVR_AST_NODE_POSTFIX_INCREMENT:
+    case XVR_AST_NODE_PREFIX_DECREMENT:
+    case XVR_AST_NODE_POSTFIX_DECREMENT:
+        return true;
+    case XVR_AST_NODE_FN_RETURN:
+        return has_side_effects_node(node->returns.returns);
+    default:
+        return false;
+    }
+}
+
+static Xvr_ASTOptimizerResult run_dead_code_elimination(Xvr_ASTNode** node,
+                                                        void* context) {
+    (void)context;
+    Xvr_ASTOptimizerResult result = {XVR_OPT_RESULT_SUCCESS, 0, NULL};
+
+    if (!node || !*node) {
+        return result;
+    }
+
+    Xvr_ASTNode* n = *node;
+
+    if (n->type == XVR_AST_NODE_IF) {
+        if (n->pathIf.condition && is_bool_literal(n->pathIf.condition)) {
+            bool cond_value = get_bool_value(n->pathIf.condition);
+            Xvr_ASTNode* keep =
+                cond_value ? n->pathIf.thenPath : n->pathIf.elsePath;
+            Xvr_ASTNode* discard =
+                cond_value ? n->pathIf.elsePath : n->pathIf.thenPath;
+
+            if (discard && !has_side_effects_node(discard)) {
+                if (keep) {
+                    Xvr_freeASTNode(n);
+                    *node = keep;
+                } else {
+                    Xvr_emitASTNodeBlock(node);
+                }
+                result.changes_made++;
+                return result;
+            }
+        }
+    }
+
+    return result;
+}
+
+bool Xvr_ASTOptimizerAddStandardPasses(Xvr_ASTOptimizer* opt) {
+    if (!opt) {
+        return false;
+    }
+
+    Xvr_ConstantFoldingContext* cf_ctx =
+        calloc(1, sizeof(Xvr_ConstantFoldingContext));
+    Xvr_ASTOptimizerPass cf_pass = {.type = XVR_PASS_CONSTANT_FOLDING,
+                                    .name = "constant_folding",
+                                    .run = run_constant_folding,
+                                    .context = cf_ctx,
+                                    .priority = 1,
+                                    .enabled = true};
+    Xvr_ASTOptimizerAddPass(opt, &cf_pass);
+
+    Xvr_DCEContext* dce_ctx = calloc(1, sizeof(Xvr_DCEContext));
+    Xvr_ASTOptimizerPass dce_pass = {.type = XVR_PASS_DEAD_CODE_ELIMINATION,
+                                     .name = "dead_code_elimination",
+                                     .run = run_dead_code_elimination,
+                                     .context = dce_ctx,
+                                     .priority = 2,
+                                     .enabled = true};
+    Xvr_ASTOptimizerAddPass(opt, &dce_pass);
+
+    return true;
+}

--- a/src/optimizer/xvr_ast_optimizer.c
+++ b/src/optimizer/xvr_ast_optimizer.c
@@ -77,8 +77,8 @@ bool Xvr_ASTOptimizerAddPass(Xvr_ASTOptimizer* opt,
     if (!opt || !pass) {
         return false;
     }
-    if (opt->pass_count >= opt->pass_capacity) {
-        int new_cap = opt->pass_capacity * 2;
+    if (!opt->passes || opt->pass_count >= opt->pass_capacity) {
+        int new_cap = opt->pass_capacity > 0 ? opt->pass_capacity * 2 : 4;
         Xvr_ASTOptimizerPass* new_passes =
             realloc(opt->passes, new_cap * sizeof(Xvr_ASTOptimizerPass));
         if (!new_passes) {

--- a/src/optimizer/xvr_ast_optimizer.h
+++ b/src/optimizer/xvr_ast_optimizer.h
@@ -1,0 +1,93 @@
+/**
+MIT License
+
+Copyright (c) 2025 arfy slowy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef XVR_AST_OPTIMIZER_H
+#define XVR_AST_OPTIMIZER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "xvr_ast_node.h"
+
+typedef struct Xvr_ASTOptimizer Xvr_ASTOptimizer;
+typedef struct Xvr_ASTOptimizerPass Xvr_ASTOptimizerPass;
+typedef struct Xvr_ASTOptimizerResult Xvr_ASTOptimizerResult;
+
+typedef enum {
+    XVR_OPT_LEVEL_NONE,
+    XVR_OPT_LEVEL_O1,
+    XVR_OPT_LEVEL_O2,
+    XVR_OPT_LEVEL_O3,
+    XVR_OPT_LEVEL_OS
+} Xvr_OptimizationLevel;
+
+typedef enum {
+    XVR_PASS_CONSTANT_FOLDING,
+    XVR_PASS_CONSTANT_PROPAGATION,
+    XVR_PASS_DEAD_CODE_ELIMINATION,
+    XVR_PASS_ALGEBRAIC_SIMPLIFICATION,
+    XVR_PASS_STRENGTH_REDUCTION,
+    XVR_PASS_FUNCTION_INLINING
+} Xvr_ASTPassType;
+
+typedef enum {
+    XVR_OPT_RESULT_SUCCESS,
+    XVR_OPT_RESULT_ERROR,
+    XVR_OPT_RESULT_NO_CHANGE
+} Xvr_OptResultCode;
+
+struct Xvr_ASTOptimizerResult {
+    Xvr_OptResultCode code;
+    int changes_made;
+    const char* error_message;
+};
+
+typedef Xvr_ASTOptimizerResult (*Xvr_ASTPassRunFn)(Xvr_ASTNode** node,
+                                                   void* context);
+
+struct Xvr_ASTOptimizerPass {
+    Xvr_ASTPassType type;
+    const char* name;
+    Xvr_ASTPassRunFn run;
+    void* context;
+    int priority;
+    bool enabled;
+};
+
+Xvr_ASTOptimizer* Xvr_ASTOptimizerCreate(void);
+void Xvr_ASTOptimizerDestroy(Xvr_ASTOptimizer* opt);
+
+void Xvr_ASTOptimizerSetLevel(Xvr_ASTOptimizer* opt,
+                              Xvr_OptimizationLevel level);
+
+bool Xvr_ASTOptimizerAddPass(Xvr_ASTOptimizer* opt, Xvr_ASTOptimizerPass* pass);
+
+bool Xvr_ASTOptimizerAddStandardPasses(Xvr_ASTOptimizer* opt);
+
+Xvr_ASTOptimizerResult Xvr_ASTOptimizerRun(Xvr_ASTOptimizer* opt,
+                                           Xvr_ASTNode** nodes, int node_count);
+
+Xvr_OptimizationLevel Xvr_OptimizationLevelFromInt(int level);
+
+#endif

--- a/src/xvr_common.c
+++ b/src/xvr_common.c
@@ -29,6 +29,40 @@ SOFTWARE.
 #include <stdlib.h>
 #include <string.h>
 
+static size_t safe_strlen(const char* str) {
+    size_t len = 0;
+    while (str[len] != '\0') {
+        len++;
+    }
+    return len;
+}
+
+static int safe_strcmp(const char* a, const char* b) {
+    size_t i = 0;
+    while (a[i] != '\0' && b[i] != '\0') {
+        if (a[i] != b[i]) {
+            return a[i] < b[i] ? -1 : 1;
+        }
+        i++;
+    }
+    if (a[i] == '\0' && b[i] == '\0') {
+        return 0;
+    }
+    return a[i] == '\0' ? -1 : 1;
+}
+
+static int safe_strncmp(const char* a, const char* b, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        if (a[i] != b[i]) {
+            return a[i] < b[i] ? -1 : 1;
+        }
+        if (a[i] == '\0') {
+            return 0;
+        }
+    }
+    return 0;
+}
+
 char* Xvr_strdup(const char* str) {
     if (!str) return NULL;
     size_t len = strlen(str) + 1;
@@ -119,9 +153,10 @@ void Xvr_initCommandLine(int argc, const char* argv[]) {
         if (!strcmp(argv[i], "-c") || !strcmp(argv[i], "--compile")) {
             Xvr_commandLine.compileOnly = true;
             if (i + 1 < argc) {
-                size_t len = strlen(argv[i + 1]);
+                size_t len = safe_strlen(argv[i + 1]);
                 if (argv[i + 1][0] != '-' &&
-                    !(len >= 4 && strcmp(&argv[i + 1][len - 4], ".xvr") == 0)) {
+                    !(len >= 4 &&
+                      safe_strcmp(&argv[i + 1][len - 4], ".xvr") == 0)) {
                     Xvr_commandLine.outFile = (char*)argv[i + 1];
                     i++;
                 }

--- a/src/xvr_common.c
+++ b/src/xvr_common.c
@@ -84,8 +84,14 @@ void Xvr_initCommandLine(int argc, const char* argv[]) {
             continue;
         }
 
-        if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--version")) {
+        if (!strcmp(argv[i], "--version")) {
             Xvr_commandLine.version = true;
+            Xvr_commandLine.error = false;
+            continue;
+        }
+
+        if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--verbose")) {
+            Xvr_commandLine.verbose = true;
             Xvr_commandLine.error = false;
             continue;
         }
@@ -176,21 +182,18 @@ void Xvr_initCommandLine(int argc, const char* argv[]) {
 
         if (!strcmp(argv[i], "--dump-tokens") || !strcmp(argv[i], "-Z")) {
             Xvr_commandLine.dumpTokens = true;
-            Xvr_commandLine.verbose = true;
             Xvr_commandLine.error = false;
             continue;
         }
 
         if (!strcmp(argv[i], "--dump-ast")) {
             Xvr_commandLine.dumpAST = true;
-            Xvr_commandLine.verbose = true;
             Xvr_commandLine.error = false;
             continue;
         }
 
         if (!strcmp(argv[i], "--timing")) {
             Xvr_commandLine.showTiming = true;
-            Xvr_commandLine.verbose = true;
             Xvr_commandLine.error = false;
             continue;
         }
@@ -227,12 +230,16 @@ void Xvr_helpCommandLine(int argc, const char* argv[]) {
 
     printf("USAGE:\n");
     printf(
-        "  xvr <source.xvr>              Compile and run (produces temp "
+        "  xvr [flags] <source.xvr>    Compile and run (produces temp "
         "binary)\n");
-    printf("  xvr <source.xvr> -o <output>   Compile to executable\n");
-    printf("  xvr <source.xvr> -c <output.o> Compile to object file only\n");
-    printf("  xvr <source.xvr> -S             Output LLVM IR to stdout\n");
-    printf("  xvr <source.xvr> -l             Output LLVM IR to stdout\n");
+    printf("  xvr [flags] <source.xvr> -o <output>   Compile to executable\n");
+    printf(
+        "  xvr [flags] <source.xvr> -c <output.o> Compile to object file "
+        "only\n");
+    printf(
+        "  xvr [flags] <source.xvr> -S             Output LLVM IR to stdout\n");
+    printf(
+        "  xvr [flags] <source.xvr> -l             Output LLVM IR to stdout\n");
     printf("  xvr -i '<code>'                Compile and run inline code\n\n");
 
     printf("OPTIONS:\n");
@@ -244,6 +251,7 @@ void Xvr_helpCommandLine(int argc, const char* argv[]) {
     printf(
         "  -r                        Compile and immediately run (default)\n");
     printf("  -d, --debug               Enable verbose debug output\n");
+    printf("  -v, --verbose             Show detailed compilation info\n");
     printf(
         "  -i, --input <code>       Compile and run inline XVR code string\n");
     printf(
@@ -253,12 +261,21 @@ void Xvr_helpCommandLine(int argc, const char* argv[]) {
     printf(
         "  -n                        Disable trailing newline in print "
         "statements\n");
-    printf("  -O<0|1|2|3>               Optimization level (default: -O0)\n");
+    printf("  -O<0|1|2|3>              Optimization level (default: -O0)\n");
     printf("  -Z, --dump-tokens        Dump all lexer tokens to stderr\n");
     printf("  --dump-ast               Dump parsed AST to stderr\n");
     printf("  --timing                 Show compilation timing breakdown\n\n");
 
+    printf("OPTIMIZATION LEVELS:\n");
+    printf("  -O0                      No optimization (fastest compile)\n");
+    printf("  -O1                      Basic optimizations\n");
+    printf("  -O2                      Balanced optimizations (default)\n");
+    printf("  -O3                      Aggressive optimizations\n\n");
+
     printf("ARGUMENTS:\n");
+    printf(
+        "  [flags]                   Optional flags (can be placed before or "
+        "after file)\n");
     printf("  <source.xvr>              XVR source file to compile\n");
     printf(
         "  <output>                  Output executable or object file name\n");
@@ -267,6 +284,9 @@ void Xvr_helpCommandLine(int argc, const char* argv[]) {
     printf("EXAMPLES:\n");
     printf("  Compile and run a source file:\n");
     printf("    $ xvr hello.xvr\n\n");
+    printf("  Compile with optimization (flag before file):\n");
+    printf("    $ xvr -O2 hello.xvr\n");
+    printf("    $ xvr -O3 -d hello.xvr\n\n");
     printf("  Compile to executable with custom name:\n");
     printf("    $ xvr hello.xvr -o myprogram\n");
     printf("    $ ./myprogram\n\n");
@@ -274,9 +294,12 @@ void Xvr_helpCommandLine(int argc, const char* argv[]) {
     printf("    $ xvr hello.xvr -c hello.o\n\n");
     printf("  Output LLVM IR for inspection:\n");
     printf("    $ xvr hello.xvr -l\n");
-    printf("    $ xvr hello.xvr -S\n\n");
-    printf("  Compile with optimization:\n");
-    printf("    $ xvr -O2 hello.xvr -o hello\n\n");
+    printf("    $ xvr -S hello.xvr\n\n");
+    printf("  Verbose compilation with timing:\n");
+    printf("    $ xvr -v --timing hello.xvr\n");
+    printf("    $ xvr --timing -O2 hello.xvr\n\n");
+    printf("  Compile with optimization and verbose:\n");
+    printf("    $ xvr -O2 -v hello.xvr -o hello\n\n");
     printf("  Compile inline code and run:\n");
     printf("    $ xvr -i 'print(\"Hello World\")'\n\n");
     printf("  Show compiler version:\n");

--- a/src/xvr_common.c
+++ b/src/xvr_common.c
@@ -118,9 +118,13 @@ void Xvr_initCommandLine(int argc, const char* argv[]) {
 
         if (!strcmp(argv[i], "-c") || !strcmp(argv[i], "--compile")) {
             Xvr_commandLine.compileOnly = true;
-            if (i + 1 < argc && argv[i + 1][0] != '-') {
-                Xvr_commandLine.outFile = (char*)argv[i + 1];
-                i++;
+            if (i + 1 < argc) {
+                size_t len = strlen(argv[i + 1]);
+                if (argv[i + 1][0] != '-' &&
+                    !(len >= 4 && strcmp(&argv[i + 1][len - 4], ".xvr") == 0)) {
+                    Xvr_commandLine.outFile = (char*)argv[i + 1];
+                    i++;
+                }
             }
             Xvr_commandLine.error = false;
             continue;
@@ -230,14 +234,18 @@ void Xvr_helpCommandLine(int argc, const char* argv[]) {
 
     printf("USAGE:\n");
     printf(
-        "  xvr [flags] <source.xvr>    Compile and run (produces temp "
-        "binary)\n");
+        "  xvr [flags] <source.xvr>      Compile and run (default: creates "
+        "'source' executable)\n");
     printf("  xvr [flags] <source.xvr> -o <output>   Compile to executable\n");
     printf(
-        "  xvr [flags] <source.xvr> -c <output.o> Compile to object file "
-        "only\n");
+        "  xvr [flags] <source.xvr> -c [output]  Compile to object file "
+        "(default: source.o)\n");
     printf(
-        "  xvr [flags] <source.xvr> -S             Output LLVM IR to stdout\n");
+        "  xvr [flags] <source.xvr> --emit asm       Output assembly (default: "
+        "source.s)\n");
+    printf(
+        "  xvr [flags] <source.xvr> --emit llvm-ir  Output LLVM IR (default: "
+        "source.ll)\n");
     printf(
         "  xvr [flags] <source.xvr> -l             Output LLVM IR to stdout\n");
     printf("  xvr -i '<code>'                Compile and run inline code\n\n");
@@ -245,8 +253,8 @@ void Xvr_helpCommandLine(int argc, const char* argv[]) {
     printf("OPTIONS:\n");
     printf("  -h, --help               Display this help message and exit\n");
     printf("  -v, --version            Display version information and exit\n");
-    printf("  -o, --output <file>      Output file name (default: a.out)\n");
-    printf("  -c, --compile <file>     Compile to object file (don't link)\n");
+    printf("  -o, --output <file>      Output file name\n");
+    printf("  -c, --compile [file]     Compile to object file (.o)\n");
     printf("  -S, -l, --llvm           Output LLVM IR to stdout\n");
     printf(
         "  -r                        Compile and immediately run (default)\n");
@@ -265,6 +273,17 @@ void Xvr_helpCommandLine(int argc, const char* argv[]) {
     printf("  -Z, --dump-tokens        Dump all lexer tokens to stderr\n");
     printf("  --dump-ast               Dump parsed AST to stderr\n");
     printf("  --timing                 Show compilation timing breakdown\n\n");
+
+    printf("OUTPUT TYPES:\n");
+    printf("  -e asm                   Emit assembly (.s file)\n");
+    printf("  -e llvm-ir              Emit LLVM IR (.ll file)\n");
+    printf("  -e obj                  Emit object file (.o file)\n\n");
+
+    printf("DEFAULT OUTPUT FILES:\n");
+    printf("  (no flag)               Executable (source name without .xvr)\n");
+    printf("  -c                       Object file (.o)\n");
+    printf("  --emit asm               Assembly (.s)\n");
+    printf("  --emit llvm-ir           LLVM IR (.ll)\n\n");
 
     printf("OPTIMIZATION LEVELS:\n");
     printf("  -O0                      No optimization (fastest compile)\n");

--- a/src/xvr_lexer.c
+++ b/src/xvr_lexer.c
@@ -282,13 +282,8 @@ static Xvr_Token makeIntegerOrFloat(Xvr_Lexer* lexer) {
     token.line = lexer->line;
 
 #ifndef XVR_EXPORT
-    if (Xvr_commandLine.verbose) {
-        if (type == XVR_TOKEN_LITERAL_INTEGER) {
-            printf("int:");
-        } else {
-            printf("int suffix:");
-        }
-        Xvr_private_printToken(&token);
+    if (Xvr_commandLine.dumpTokens) {
+        printf("int:");
     }
 #endif
 
@@ -338,9 +333,8 @@ static Xvr_Token makeString(Xvr_Lexer* lexer, char terminator) {
     token.line = lexer->line;
 
 #ifndef XVR_EXPORT
-    if (Xvr_commandLine.verbose) {
+    if (Xvr_commandLine.dumpTokens) {
         printf("str:");
-        Xvr_private_printToken(&token);
     }
 #endif
 
@@ -368,9 +362,8 @@ static Xvr_Token makeKeywordOrIdentifier(Xvr_Lexer* lexer) {
             token.line = lexer->line;
 
 #ifndef XVR_EXPORT
-            if (Xvr_commandLine.verbose) {
+            if (Xvr_commandLine.dumpTokens) {
                 printf("kwd:");
-                Xvr_private_printToken(&token);
             }
 #endif
 
@@ -387,9 +380,8 @@ static Xvr_Token makeKeywordOrIdentifier(Xvr_Lexer* lexer) {
     token.line = lexer->line;
 
 #ifndef XVR_EXPORT
-    if (Xvr_commandLine.verbose) {
+    if (Xvr_commandLine.dumpTokens) {
         printf("idf:");
-        Xvr_private_printToken(&token);
     }
 #endif
 

--- a/src/xvr_memory.c
+++ b/src/xvr_memory.c
@@ -38,6 +38,9 @@ void Xvr_debugResetMemoryStats(void) {
 
 void* Xvr_private_defaultMemoryAllocator(void* pointer, size_t oldSize,
                                          size_t newSize) {
+    /* NOTE: This allocator uses standard malloc/free - consider arena
+       allocation for performance-critical code paths to reduce allocation
+       overhead */
 #if XVR_DEBUG_ALLOCATIONS
     if (!g_initialized) {
         g_initialized = 1;


### PR DESCRIPTION
add constant folding for deterministic, side-effect-free functions with
constant arguments. this allows expressions such as FNV-1a hash on string literals
to be evaluated at compile time and replaced with immediate values in IR/assembly.

key points:
- detect pure functions with no side effects
- evaluate calls when all inputs are compile-time constants
- replace call sites with constant results
- reduce runtime overhead and eliminate unnecessary loops